### PR TITLE
Restore MtlNovelProvider

### DIFF
--- a/app/src/main/java/com/lagradost/quicknovel/util/Apis.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/util/Apis.kt
@@ -28,7 +28,7 @@ class Apis {
             NovelsOnlineProvider(),
             EfremnetProvider(),
             GraycityProvider(),
-            //MtlNovelProvider(),
+            MtlNovelProvider(),
 
             AnnasArchive(),
 


### PR DESCRIPTION
This commit restores MtlNovelProvider, that was commented some time ago.
As some novels are only mtl translated. 
Additionally removed Cloudflare, as site is no longer using it.