### PR TITLE
freewebnovel first p fixed

### DIFF
--- a/app/src/main/java/com/lagradost/quicknovel/providers/FreeWebNovelProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/FreeWebNovelProvider.kt
@@ -46,7 +46,6 @@ class FreewebnovelProvider : LibReadProvider() {
                     ""
                 )
         )
-        document.selectFirst("p")?.remove() // .m-read .txt sub, .m-read .txt p:nth-child(1)
         /*for (e in document.select("p")) {
             if (e.text().contains("The source of this ") || e.selectFirst("a")?.hasAttr("href") == true) {
                 e.remove()


### PR DESCRIPTION
In the freewebnovel provider, the first paragraph of all novels was being removed. This was caused by a line of code that deleted the first p. In this pull request, I suggest removing that line