### PR TITLE
Downloading update notification

### DIFF
--- a/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
@@ -864,34 +864,12 @@ object NotificationHelper {
 
     suspend fun createNotification(
         context: Context?,
-        source: String,
-        id: Int,
-        load: LoadResponse,
-        stateProgressState: DownloadProgressState,
-        showNotification: Boolean,
-        progressInBytes: Boolean,
-    ){
-        createNotification(
-            context = context,
-            source = source,
-            id = id,
-            name = load.name,
-            posterUrl = load.posterUrl,
-            stateProgressState = stateProgressState,
-            progressInBytes = progressInBytes,
-            showNotification = showNotification
-        )
-    }
-
-    suspend fun createNotification(
-        context: Context?,
         source: String?,
         id: Int,
         name: String,
         posterUrl: String? = null,
         stateProgressState: DownloadProgressState,
         progressInBytes: Boolean = true,
-        showNotification: Boolean = true,
         isActionable: Boolean = true,
         isStreamNovel: Boolean = true,
     ) {
@@ -901,114 +879,113 @@ object NotificationHelper {
             stateProgressState.etaMs
         ) else ""
 
-        if(showNotification){
-            val intent = Intent(context, MainActivity::class.java).apply {
-                data = source?.toUri()
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-            }
+        val intent = Intent(context, MainActivity::class.java).apply {
+            data = source?.toUri()
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
 
-            val pendingIntent: PendingIntent = PendingIntent.getActivity(
-                context, 0, intent,
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
+        val pendingIntent: PendingIntent = PendingIntent.getActivity(
+            context, 0, intent,
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
+        )
+
+        val builder = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setAutoCancel(true)
+            .setColorized(true)
+            .setOnlyAlertOnce(true)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setColor(context.colorFromAttribute(R.attr.colorPrimary))
+            .setContentTitle(name)
+            .setContentIntent(pendingIntent)
+
+
+        val extraText = if (stateProgressState.total > 1) {
+            val unit = if (progressInBytes) "Kb" else ""
+            val div = if (progressInBytes) 1024 else 1
+
+            if(isStreamNovel)
+                "${stateProgressState.progress} / ${stateProgressState.total}"
+            else
+                "${stateProgressState.progress / div} $unit / ${stateProgressState.total / div}${if(unit.isNotEmpty()) " $unit" else ""}"
+        } else ""
+
+        val statusText = when (state) {
+            DownloadState.IsDone -> "Download Done"
+            DownloadState.IsDownloading -> "Downloading $extraText"
+            DownloadState.IsPaused -> "Paused $extraText"
+            DownloadState.IsFailed -> "Error $extraText"
+            DownloadState.IsStopped -> "Stopped $extraText"
+            else -> ""
+        }
+        builder.setContentText(statusText)
+
+        builder.setSmallIcon(
+            when (state) {
+                DownloadState.IsDone -> R.drawable.rddone
+                DownloadState.IsDownloading -> R.drawable.rdload
+                DownloadState.IsPaused -> R.drawable.rdpause
+                else -> R.drawable.rderror
+            }
+        )
+
+
+        if (state == DownloadState.IsDownloading || state == DownloadState.IsPaused) {
+            builder.setProgress(
+                stateProgressState.total.toInt(),
+                stateProgressState.progress.toInt(),
+                stateProgressState.total <= 1
             )
-
-            val builder = NotificationCompat.Builder(context, CHANNEL_ID)
-                .setAutoCancel(true)
-                .setColorized(true)
-                .setOnlyAlertOnce(true)
-                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-                .setColor(context.colorFromAttribute(R.attr.colorPrimary))
-                .setContentTitle(name)
-                .setContentIntent(pendingIntent)
+            if (timeFormat.isNotEmpty()) builder.setSubText("$timeFormat remaining")
+        }
 
 
-            val extraText = if (stateProgressState.total > 1) {
-                val unit = if (progressInBytes) "Kb" else ""
-                val div = if (progressInBytes) 1024 else 1
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && posterUrl != null) {
+            context.getImageBitmapFromUrl(posterUrl)?.let { builder.setLargeIcon(it) }
+        }
 
-                if(isStreamNovel)
-                    "${stateProgressState.progress} / ${stateProgressState.total}"
-                else
-                    "${stateProgressState.progress / div} $unit / ${stateProgressState.total / div}${if(unit.isNotEmpty()) " $unit" else ""}"
-            } else ""
 
-            val statusText = when (state) {
-                DownloadState.IsDone -> "Download Done"
-                DownloadState.IsDownloading -> "Downloading $extraText"
-                DownloadState.IsPaused -> "Paused $extraText"
-                DownloadState.IsFailed -> "Error $extraText"
-                DownloadState.IsStopped -> "Stopped $extraText"
-                else -> ""
-            }
-            builder.setContentText(statusText)
+        if (isActionable && (state == DownloadState.IsDownloading || state == DownloadState.IsPaused)) {
+            val actionTypes = if (state == DownloadState.IsDownloading)
+                listOf(DownloadActionType.Pause, DownloadActionType.Stop)
+            else
+                listOf(DownloadActionType.Resume, DownloadActionType.Stop)
 
-            builder.setSmallIcon(
-                when (state) {
-                    DownloadState.IsDone -> R.drawable.rddone
-                    DownloadState.IsDownloading -> R.drawable.rdload
-                    DownloadState.IsPaused -> R.drawable.rdpause
-                    else -> R.drawable.rderror
+            actionTypes.forEachIndexed { index, action ->
+                val resultIntent = Intent(context, DownloadNotificationService::class.java).apply {
+                    putExtra("type", action.name.lowercase())
+                    putExtra("id", id)
                 }
-            )
 
-
-            if (state == DownloadState.IsDownloading || state == DownloadState.IsPaused) {
-                builder.setProgress(
-                    stateProgressState.total.toInt(),
-                    stateProgressState.progress.toInt(),
-                    stateProgressState.total <= 1
+                val pending: PendingIntent = PendingIntent.getService(
+                    context, 4337 + index + id, resultIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0)
                 )
-                if (timeFormat.isNotEmpty()) builder.setSubText("$timeFormat remaining")
-            }
 
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && posterUrl != null) {
-                context.getImageBitmapFromUrl(posterUrl)?.let { builder.setLargeIcon(it) }
-            }
-
-
-            if (isActionable && (state == DownloadState.IsDownloading || state == DownloadState.IsPaused)) {
-                val actionTypes = if (state == DownloadState.IsDownloading)
-                    listOf(DownloadActionType.Pause, DownloadActionType.Stop)
-                else
-                    listOf(DownloadActionType.Resume, DownloadActionType.Stop)
-
-                actionTypes.forEachIndexed { index, action ->
-                    val resultIntent = Intent(context, DownloadNotificationService::class.java).apply {
-                        putExtra("type", action.name.lowercase())
-                        putExtra("id", id)
-                    }
-
-                    val pending: PendingIntent = PendingIntent.getService(
-                        context, 4337 + index + id, resultIntent,
-                        PendingIntent.FLAG_UPDATE_CURRENT or (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0)
+                builder.addAction(
+                    NotificationCompat.Action(
+                        when (action) {
+                            DownloadActionType.Resume -> R.drawable.rdload
+                            DownloadActionType.Pause -> R.drawable.rdpause
+                            DownloadActionType.Stop -> R.drawable.rderror
+                        },
+                        action.name, pending
                     )
-
-                    builder.addAction(
-                        NotificationCompat.Action(
-                            when (action) {
-                                DownloadActionType.Resume -> R.drawable.rdload
-                                DownloadActionType.Pause -> R.drawable.rdpause
-                                DownloadActionType.Stop -> R.drawable.rderror
-                            },
-                            action.name, pending
-                        )
-                    )
-                }
-            }
-
-            if (!hasCreatedNotChanel) {
-                context.createNotificationChannel()
-            }
-
-            with(NotificationManagerCompat.from(context)) {
-                try {
-                    notify(id, builder.build())
-                } catch (t: Throwable) {
-                    logError(t)
-                }
+                )
             }
         }
+
+        if (!hasCreatedNotChanel) {
+            context.createNotificationChannel()
+        }
+
+        with(NotificationManagerCompat.from(context)) {
+            try {
+                notify(id, builder.build())
+            } catch (t: Throwable) {
+                logError(t)
+            }
+        }
+
     }
 }
 
@@ -1388,12 +1365,15 @@ object BookDownloader2 {
         id: Int,
         load: LoadResponse,
         stateProgressState: DownloadProgressState,
-        show: Boolean = true,
         progressInBytes: Boolean = false
     ) {
         NotificationHelper.createNotification(
             activity,
-            load.url, id, load, stateProgressState, show, progressInBytes
+            load.url, id,
+            load.name,
+            load.posterUrl,
+            stateProgressState,
+            progressInBytes
         )
     }
 

--- a/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
@@ -2540,10 +2540,10 @@ object BookDownloader2 {
         } catch (t: Throwable) {
             // also set it here in case of exception
             logError(t)
+            changeDownload(id) { state = DownloadState.IsFailed }
             if (downloadedTotal > 0) {
                 setSuffixData(load, api.name)
             }
-            changeDownload(id) { state = DownloadState.IsFailed }
         } finally {
             currentDownloadsMutex.withLock {
                 currentDownloads -= id

--- a/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
@@ -673,7 +673,11 @@ object BookDownloader2Helper {
                         delay(api.rateLimitTime)
                     }
                 }
-            } finally {
+            }
+            catch(t: Throwable){
+                logError(t)
+            }
+            finally {
                 if (rateLimit) {
                     api.api.rateLimitMutex.unlock()
                 }
@@ -869,156 +873,136 @@ object NotificationHelper {
         stateProgressState: DownloadProgressState,
         showNotification: Boolean,
         progressInBytes: Boolean,
+    ){
+        createNotification(
+            context,
+            source,
+            id,
+            load.name,
+            load.posterUrl,
+            stateProgressState,
+            showNotification,
+            progressInBytes
+        )
+    }
+
+    suspend fun createNotification(
+        context: Context?,
+        source: String,
+        id: Int,
+        name: String,
+        posterUrl: String? = null,
+        stateProgressState: DownloadProgressState,
+        showNotification: Boolean = true,
+        progressInBytes: Boolean = true,
+        isActionable: Boolean = true
     ) {
-        if (context == null) return
+        if (context == null || !showNotification) return
         val state = stateProgressState.state
-        var timeFormat = ""
-        if (state == DownloadState.IsDownloading) { // ETA
-            timeFormat = etaToString(stateProgressState.etaMs)
+        val timeFormat = if (state == DownloadState.IsDownloading) etaToString(
+            stateProgressState.etaMs
+        ) else ""
+
+        val intent = Intent(context, MainActivity::class.java).apply {
+            data = source.toUri()
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         }
 
-        if (showNotification) {
-            val intent = Intent(context, MainActivity::class.java).apply {
-                data = source.toUri()
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-            }
+        val pendingIntent: PendingIntent = PendingIntent.getActivity(
+            context, 0, intent,
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
+        )
 
-            val pendingIntent: PendingIntent = PendingIntent.getActivity(
-                context, 0, intent,
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
-                    PendingIntent.FLAG_MUTABLE else 0
+        val builder = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setAutoCancel(true)
+            .setColorized(true)
+            .setOnlyAlertOnce(true)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setColor(context.colorFromAttribute(R.attr.colorPrimary))
+            .setContentTitle(name)
+            .setContentIntent(pendingIntent)
+
+
+        val extraText = if (stateProgressState.total > 1) {
+            val unit = if (progressInBytes) "Kb" else ""
+            val div = if (progressInBytes) 1024 else 1
+            "${stateProgressState.progress / div} $unit / ${stateProgressState.total / div} $unit"
+        } else ""
+
+        val statusText = when (state) {
+            DownloadState.IsDone -> "Download Done"
+            DownloadState.IsDownloading -> "Downloading $extraText"
+            DownloadState.IsPaused -> "Paused $extraText"
+            DownloadState.IsFailed -> "Error $extraText"
+            DownloadState.IsStopped -> "Stopped $extraText"
+            else -> ""
+        }
+        builder.setContentText(statusText)
+
+        builder.setSmallIcon(
+            when (state) {
+                DownloadState.IsDone -> R.drawable.rddone
+                DownloadState.IsDownloading -> R.drawable.rdload
+                DownloadState.IsPaused -> R.drawable.rdpause
+                else -> R.drawable.rderror
+            }
+        )
+
+
+        if (state == DownloadState.IsDownloading || state == DownloadState.IsPaused) {
+            builder.setProgress(
+                stateProgressState.total.toInt(),
+                stateProgressState.progress.toInt(),
+                stateProgressState.total <= 1
             )
-            val builder = NotificationCompat.Builder(context, CHANNEL_ID)
-                .setAutoCancel(true)
-                .setColorized(true)
-                .setAutoCancel(true)
-                .setOnlyAlertOnce(true)
-                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-                .setColor(context.colorFromAttribute(R.attr.colorPrimary))
-                .setContentText(
-                    if (stateProgressState.total > 1) {
-                        val extra = if (progressInBytes) {
-                            val bytesToKiloBytes = 1024
-                            "${stateProgressState.progress / bytesToKiloBytes} Kb/${stateProgressState.total / bytesToKiloBytes} Kb"
-                        } else {
-                            "${stateProgressState.progress}/${stateProgressState.total}"
-                        }
+            if (timeFormat.isNotEmpty()) builder.setSubText("$timeFormat remaining")
+        }
 
-                        when (state) {
-                            DownloadState.IsDone -> "Download Done - ${load.name}"
-                            DownloadState.IsDownloading -> "Downloading ${load.name} - $extra"
-                            DownloadState.IsPaused -> "Paused ${load.name} - $extra"
-                            DownloadState.IsFailed -> "Error ${load.name} - $extra"
-                            DownloadState.IsStopped -> "Stopped ${load.name} - $extra"
-                            else -> throw NotImplementedError()
-                        }
-                    } else {
-                        when (state) {
-                            DownloadState.IsDone -> "Download Done - ${load.name}"
-                            DownloadState.IsDownloading -> "Downloading ${load.name}"
-                            DownloadState.IsPaused -> "Paused ${load.name}"
-                            DownloadState.IsFailed -> "Error ${load.name}"
-                            DownloadState.IsStopped -> "Stopped ${load.name}"
-                            else -> throw NotImplementedError()
-                        }
-                    }
-                )
-                .setSmallIcon(
-                    when (state) {
-                        DownloadState.IsDone -> R.drawable.rddone
-                        DownloadState.IsDownloading -> R.drawable.rdload
-                        DownloadState.IsPaused -> R.drawable.rdpause
-                        DownloadState.IsFailed -> R.drawable.rderror
-                        DownloadState.IsStopped -> R.drawable.rderror
-                        else -> throw NotImplementedError()
-                    }
-                )
-                .setContentIntent(pendingIntent)
 
-            if (state == DownloadState.IsDownloading && stateProgressState.total > 2) {
-                builder.setSubText("$timeFormat remaining")
-            }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && posterUrl != null) {
+            context.getImageBitmapFromUrl(posterUrl)?.let { builder.setLargeIcon(it) }
+        }
 
-            if (state == DownloadState.IsDownloading || state == DownloadState.IsPaused) {
-                builder.setProgress(
-                    stateProgressState.total.toInt(),
-                    stateProgressState.progress.toInt(),
-                    stateProgressState.total <= 1
-                )
-            }
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                load.posterUrl?.let { url ->
-                    val poster = context.getImageBitmapFromUrl(url)
-                    if (poster != null)
-                        builder.setLargeIcon(poster)
-                }
-            }
+        if (isActionable && (state == DownloadState.IsDownloading || state == DownloadState.IsPaused)) {
+            val actionTypes = if (state == DownloadState.IsDownloading)
+                listOf(DownloadActionType.Pause, DownloadActionType.Stop)
+            else
+                listOf(DownloadActionType.Resume, DownloadActionType.Stop)
 
-            if ((state == DownloadState.IsDownloading || state == DownloadState.IsPaused) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                val actionTypes: MutableList<DownloadActionType> = ArrayList()
-                // INIT
-                if (state == DownloadState.IsDownloading) {
-                    actionTypes.add(DownloadActionType.Pause)
-                    actionTypes.add(DownloadActionType.Stop)
+            actionTypes.forEachIndexed { index, action ->
+                val resultIntent = Intent(context, DownloadNotificationService::class.java).apply {
+                    putExtra("type", action.name.lowercase())
+                    putExtra("id", id)
                 }
 
-                if (state == DownloadState.IsPaused) {
-                    actionTypes.add(DownloadActionType.Resume)
-                    actionTypes.add(DownloadActionType.Stop)
-                }
+                val pending: PendingIntent = PendingIntent.getService(
+                    context, 4337 + index + id, resultIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0)
+                )
 
-                // ADD ACTIONS
-                for ((index, i) in actionTypes.withIndex()) {
-                    val resultIntent = Intent(context, DownloadNotificationService::class.java)
-
-                    resultIntent.putExtra(
-                        "type", when (i) {
-                            DownloadActionType.Resume -> "resume"
-                            DownloadActionType.Pause -> "pause"
-                            DownloadActionType.Stop -> "stop"
-                        }
+                builder.addAction(
+                    NotificationCompat.Action(
+                        when (action) {
+                            DownloadActionType.Resume -> R.drawable.rdload
+                            DownloadActionType.Pause -> R.drawable.rdpause
+                            DownloadActionType.Stop -> R.drawable.rderror
+                        },
+                        action.name, pending
                     )
-
-                    resultIntent.putExtra("id", id)
-
-                    val pending: PendingIntent =
-                        PendingIntent.getService(
-                            context, 4337 + index + id,
-                            resultIntent,
-                            PendingIntent.FLAG_UPDATE_CURRENT or
-                                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
-                                        PendingIntent.FLAG_MUTABLE else 0
-                        )
-
-
-                    builder.addAction(
-                        NotificationCompat.Action(
-                            when (i) {
-                                DownloadActionType.Resume -> R.drawable.rdload
-                                DownloadActionType.Pause -> R.drawable.rdpause
-                                DownloadActionType.Stop -> R.drawable.rderror
-                            }, when (i) {
-                                DownloadActionType.Resume -> "Resume"
-                                DownloadActionType.Pause -> "Pause"
-                                DownloadActionType.Stop -> "Stop"
-                            }, pending
-                        )
-                    )
-                }
+                )
             }
+        }
 
-            if (!hasCreatedNotChanel) {
-                context.createNotificationChannel()
-            }
+        if (!hasCreatedNotChanel) {
+            context.createNotificationChannel()
+        }
 
-            with(NotificationManagerCompat.from(context)) {
-                // notificationId is a unique int for each notification that you must define
-                try {
-                    notify(id, builder.build())
-                } catch (t: Throwable) {
-                    logError(t)
-                }
+        with(NotificationManagerCompat.from(context)) {
+            try {
+                notify(id, builder.build())
+            } catch (t: Throwable) {
+                logError(t)
             }
         }
     }
@@ -1234,7 +1218,7 @@ object BookDownloader2 {
     }
 
 
-    suspend fun getOldDataReadingProgress(currentTabIndex: Int){
+    suspend fun getOldDataReadingProgress(currentTabIndex: Int) {
         val keys = getKeys(RESULT_BOOKMARK_STATE) ?: return
         val readList = arrayListOf(
             ReadType.READING,
@@ -1245,15 +1229,20 @@ object BookDownloader2 {
             ReadType.DROPPED,
         )
         coroutineScope {
-            for (key in keys) {
-                val state = getKey<Int>(key)
-                if (state == readList[currentTabIndex].prefValue) {
-                    val id = key.replaceFirst(RESULT_BOOKMARK_STATE, RESULT_BOOKMARK)
-                    val cached = getKey<ResultCached>(id) ?: continue
-                    launch {
-                        getNewTotalChapters(cached)
+            try {
+                for (key in keys) {
+                    val state = getKey<Int>(key)
+                    if (state == readList[currentTabIndex].prefValue) {
+                        val id = key.replaceFirst(RESULT_BOOKMARK_STATE, RESULT_BOOKMARK)
+                        val cached = getKey<ResultCached>(id) ?: continue
+                        launch {
+                            getNewTotalChapters(cached)
+                        }
                     }
                 }
+
+            } catch(t: Throwable){
+                logError(t)
             }
         }
     }
@@ -2415,7 +2404,8 @@ object BookDownloader2 {
         api: APIRepository,
         range: ClosedRange<Int>
     ) {
-        val filesDir = activity?.filesDir ?: return
+        val context = activity ?: return
+        val filesDir = context.filesDir
         val sApiName = BookDownloader2Helper.sanitizeFilename(api.name)
         val sAuthor =
             BookDownloader2Helper.sanitizeFilename(load.author ?: "")
@@ -2476,10 +2466,9 @@ object BookDownloader2 {
                         index
                     )
                 val rFile = File(filepath)
-                if (rFile.exists()) {
-                    if (rFile.length() > 10) { // TO PREVENT INVALID FILE FROM HAVING TO REMOVE EVERYTHING
-                        continue
-                    }
+                // TO PREVENT INVALID FILE FROM HAVING TO REMOVE EVERYTHING
+                if (rFile.exists() && rFile.length() > 10) {
+                    continue
                 }
 
                 val beforeDownloadTime = System.currentTimeMillis()
@@ -2554,11 +2543,11 @@ object BookDownloader2 {
             }
         } catch (t: Throwable) {
             // also set it here in case of exception
+            logError(t)
             if (downloadedTotal > 0) {
                 setSuffixData(load, api.name)
             }
-
-            logError(t)
+            changeDownload(id) { state = DownloadState.IsFailed }
         } finally {
             currentDownloadsMutex.withLock {
                 currentDownloads -= id

--- a/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
@@ -872,14 +872,14 @@ object NotificationHelper {
         progressInBytes: Boolean,
     ){
         createNotification(
-            context,
-            source,
-            id,
-            load.name,
-            load.posterUrl,
-            stateProgressState,
-            showNotification,
-            progressInBytes
+            context = context,
+            source = source,
+            id = id,
+            name = load.name,
+            posterUrl = load.posterUrl,
+            stateProgressState = stateProgressState,
+            progressInBytes = progressInBytes,
+            showNotification = showNotification
         )
     }
 
@@ -891,6 +891,7 @@ object NotificationHelper {
         posterUrl: String? = null,
         stateProgressState: DownloadProgressState,
         progressInBytes: Boolean = true,
+        showNotification: Boolean = true,
         isActionable: Boolean = true,
         isStreamNovel: Boolean = true,
     ) {
@@ -900,110 +901,112 @@ object NotificationHelper {
             stateProgressState.etaMs
         ) else ""
 
-        val intent = Intent(context, MainActivity::class.java).apply {
-            data = source?.toUri()
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-        }
-
-        val pendingIntent: PendingIntent = PendingIntent.getActivity(
-            context, 0, intent,
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
-        )
-
-        val builder = NotificationCompat.Builder(context, CHANNEL_ID)
-            .setAutoCancel(true)
-            .setColorized(true)
-            .setOnlyAlertOnce(true)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-            .setColor(context.colorFromAttribute(R.attr.colorPrimary))
-            .setContentTitle(name)
-            .setContentIntent(pendingIntent)
-
-
-        val extraText = if (stateProgressState.total > 1) {
-            val unit = if (progressInBytes) "Kb" else ""
-            val div = if (progressInBytes) 1024 else 1
-
-            if(isStreamNovel)
-                "${stateProgressState.progress} / ${stateProgressState.total}"
-            else
-                "${stateProgressState.progress / div} $unit / ${stateProgressState.total / div}${if(unit.isNotEmpty()) " $unit" else ""}"
-        } else ""
-
-        val statusText = when (state) {
-            DownloadState.IsDone -> "Download Done"
-            DownloadState.IsDownloading -> "Downloading $extraText"
-            DownloadState.IsPaused -> "Paused $extraText"
-            DownloadState.IsFailed -> "Error $extraText"
-            DownloadState.IsStopped -> "Stopped $extraText"
-            else -> ""
-        }
-        builder.setContentText(statusText)
-
-        builder.setSmallIcon(
-            when (state) {
-                DownloadState.IsDone -> R.drawable.rddone
-                DownloadState.IsDownloading -> R.drawable.rdload
-                DownloadState.IsPaused -> R.drawable.rdpause
-                else -> R.drawable.rderror
+        if(showNotification){
+            val intent = Intent(context, MainActivity::class.java).apply {
+                data = source?.toUri()
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
             }
-        )
 
-
-        if (state == DownloadState.IsDownloading || state == DownloadState.IsPaused) {
-            builder.setProgress(
-                stateProgressState.total.toInt(),
-                stateProgressState.progress.toInt(),
-                stateProgressState.total <= 1
+            val pendingIntent: PendingIntent = PendingIntent.getActivity(
+                context, 0, intent,
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
             )
-            if (timeFormat.isNotEmpty()) builder.setSubText("$timeFormat remaining")
-        }
+
+            val builder = NotificationCompat.Builder(context, CHANNEL_ID)
+                .setAutoCancel(true)
+                .setColorized(true)
+                .setOnlyAlertOnce(true)
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setColor(context.colorFromAttribute(R.attr.colorPrimary))
+                .setContentTitle(name)
+                .setContentIntent(pendingIntent)
 
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && posterUrl != null) {
-            context.getImageBitmapFromUrl(posterUrl)?.let { builder.setLargeIcon(it) }
-        }
+            val extraText = if (stateProgressState.total > 1) {
+                val unit = if (progressInBytes) "Kb" else ""
+                val div = if (progressInBytes) 1024 else 1
 
+                if(isStreamNovel)
+                    "${stateProgressState.progress} / ${stateProgressState.total}"
+                else
+                    "${stateProgressState.progress / div} $unit / ${stateProgressState.total / div}${if(unit.isNotEmpty()) " $unit" else ""}"
+            } else ""
 
-        if (isActionable && (state == DownloadState.IsDownloading || state == DownloadState.IsPaused)) {
-            val actionTypes = if (state == DownloadState.IsDownloading)
-                listOf(DownloadActionType.Pause, DownloadActionType.Stop)
-            else
-                listOf(DownloadActionType.Resume, DownloadActionType.Stop)
-
-            actionTypes.forEachIndexed { index, action ->
-                val resultIntent = Intent(context, DownloadNotificationService::class.java).apply {
-                    putExtra("type", action.name.lowercase())
-                    putExtra("id", id)
-                }
-
-                val pending: PendingIntent = PendingIntent.getService(
-                    context, 4337 + index + id, resultIntent,
-                    PendingIntent.FLAG_UPDATE_CURRENT or (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0)
-                )
-
-                builder.addAction(
-                    NotificationCompat.Action(
-                        when (action) {
-                            DownloadActionType.Resume -> R.drawable.rdload
-                            DownloadActionType.Pause -> R.drawable.rdpause
-                            DownloadActionType.Stop -> R.drawable.rderror
-                        },
-                        action.name, pending
-                    )
-                )
+            val statusText = when (state) {
+                DownloadState.IsDone -> "Download Done"
+                DownloadState.IsDownloading -> "Downloading $extraText"
+                DownloadState.IsPaused -> "Paused $extraText"
+                DownloadState.IsFailed -> "Error $extraText"
+                DownloadState.IsStopped -> "Stopped $extraText"
+                else -> ""
             }
-        }
+            builder.setContentText(statusText)
 
-        if (!hasCreatedNotChanel) {
-            context.createNotificationChannel()
-        }
+            builder.setSmallIcon(
+                when (state) {
+                    DownloadState.IsDone -> R.drawable.rddone
+                    DownloadState.IsDownloading -> R.drawable.rdload
+                    DownloadState.IsPaused -> R.drawable.rdpause
+                    else -> R.drawable.rderror
+                }
+            )
 
-        with(NotificationManagerCompat.from(context)) {
-            try {
-                notify(id, builder.build())
-            } catch (t: Throwable) {
-                logError(t)
+
+            if (state == DownloadState.IsDownloading || state == DownloadState.IsPaused) {
+                builder.setProgress(
+                    stateProgressState.total.toInt(),
+                    stateProgressState.progress.toInt(),
+                    stateProgressState.total <= 1
+                )
+                if (timeFormat.isNotEmpty()) builder.setSubText("$timeFormat remaining")
+            }
+
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && posterUrl != null) {
+                context.getImageBitmapFromUrl(posterUrl)?.let { builder.setLargeIcon(it) }
+            }
+
+
+            if (isActionable && (state == DownloadState.IsDownloading || state == DownloadState.IsPaused)) {
+                val actionTypes = if (state == DownloadState.IsDownloading)
+                    listOf(DownloadActionType.Pause, DownloadActionType.Stop)
+                else
+                    listOf(DownloadActionType.Resume, DownloadActionType.Stop)
+
+                actionTypes.forEachIndexed { index, action ->
+                    val resultIntent = Intent(context, DownloadNotificationService::class.java).apply {
+                        putExtra("type", action.name.lowercase())
+                        putExtra("id", id)
+                    }
+
+                    val pending: PendingIntent = PendingIntent.getService(
+                        context, 4337 + index + id, resultIntent,
+                        PendingIntent.FLAG_UPDATE_CURRENT or (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0)
+                    )
+
+                    builder.addAction(
+                        NotificationCompat.Action(
+                            when (action) {
+                                DownloadActionType.Resume -> R.drawable.rdload
+                                DownloadActionType.Pause -> R.drawable.rdpause
+                                DownloadActionType.Stop -> R.drawable.rderror
+                            },
+                            action.name, pending
+                        )
+                    )
+                }
+            }
+
+            if (!hasCreatedNotChanel) {
+                context.createNotificationChannel()
+            }
+
+            with(NotificationManagerCompat.from(context)) {
+                try {
+                    notify(id, builder.build())
+                } catch (t: Throwable) {
+                    logError(t)
+                }
             }
         }
     }

--- a/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
@@ -674,9 +674,6 @@ object BookDownloader2Helper {
                     }
                 }
             }
-            catch(t: Throwable){
-                logError(t)
-            }
             finally {
                 if (rateLimit) {
                     api.api.rateLimitMutex.unlock()
@@ -888,23 +885,23 @@ object NotificationHelper {
 
     suspend fun createNotification(
         context: Context?,
-        source: String,
+        source: String?,
         id: Int,
         name: String,
         posterUrl: String? = null,
         stateProgressState: DownloadProgressState,
-        showNotification: Boolean = true,
         progressInBytes: Boolean = true,
-        isActionable: Boolean = true
+        isActionable: Boolean = true,
+        isStreamNovel: Boolean = true,
     ) {
-        if (context == null || !showNotification) return
+        if (context == null) return
         val state = stateProgressState.state
         val timeFormat = if (state == DownloadState.IsDownloading) etaToString(
             stateProgressState.etaMs
         ) else ""
 
         val intent = Intent(context, MainActivity::class.java).apply {
-            data = source.toUri()
+            data = source?.toUri()
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         }
 
@@ -926,7 +923,11 @@ object NotificationHelper {
         val extraText = if (stateProgressState.total > 1) {
             val unit = if (progressInBytes) "Kb" else ""
             val div = if (progressInBytes) 1024 else 1
-            "${stateProgressState.progress / div} $unit / ${stateProgressState.total / div} $unit"
+
+            if(isStreamNovel)
+                "${stateProgressState.progress} / ${stateProgressState.total}"
+            else
+                "${stateProgressState.progress / div} $unit / ${stateProgressState.total / div}${if(unit.isNotEmpty()) " $unit" else ""}"
         } else ""
 
         val statusText = when (state) {
@@ -1229,20 +1230,15 @@ object BookDownloader2 {
             ReadType.DROPPED,
         )
         coroutineScope {
-            try {
-                for (key in keys) {
-                    val state = getKey<Int>(key)
-                    if (state == readList[currentTabIndex].prefValue) {
-                        val id = key.replaceFirst(RESULT_BOOKMARK_STATE, RESULT_BOOKMARK)
-                        val cached = getKey<ResultCached>(id) ?: continue
-                        launch {
-                            getNewTotalChapters(cached)
-                        }
+            for (key in keys) {
+                val state = getKey<Int>(key)
+                if (state == readList[currentTabIndex].prefValue) {
+                    val id = key.replaceFirst(RESULT_BOOKMARK_STATE, RESULT_BOOKMARK)
+                    val cached = getKey<ResultCached>(id) ?: continue
+                    launch {
+                        getNewTotalChapters(cached)
                     }
                 }
-
-            } catch(t: Throwable){
-                logError(t)
             }
         }
     }

--- a/app/src/main/java/com/lagradost/quicknovel/util/InAppUpdater.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/util/InAppUpdater.kt
@@ -219,7 +219,7 @@ class InAppUpdater {
                             runBlocking {
                                 NotificationHelper.createNotification(
                                     context = this@downloadUpdate,
-                                    source = url,
+                                    source = null,
                                     id = UPDATE_NOTIFICATION_ID,
                                     name = "QuickNovel Update",
                                     stateProgressState = DownloadProgressState(
@@ -231,8 +231,8 @@ class InAppUpdater {
                                         etaMs = eta
                                     ),
                                     progressInBytes = true,
-                                    isActionable = false
-
+                                    isActionable = false,
+                                    isStreamNovel = false,
                                 )
                             }
                             lastUpdateTime = currentTime
@@ -267,8 +267,7 @@ class InAppUpdater {
                             clen.toLong(),
                             clen.toLong(),
                             lastUpdateTime,
-                            null),
-                        showNotification = false
+                            null)
                     )
                 }
 

--- a/app/src/main/java/com/lagradost/quicknovel/util/InAppUpdater.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/util/InAppUpdater.kt
@@ -17,9 +17,13 @@ import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.lagradost.quicknovel.BuildConfig
 import com.lagradost.quicknovel.CommonActivity.showToast
+import com.lagradost.quicknovel.DownloadProgressState
+import com.lagradost.quicknovel.DownloadState
 import com.lagradost.quicknovel.MainActivity.Companion.app
+import com.lagradost.quicknovel.NotificationHelper
 import com.lagradost.quicknovel.R
 import com.lagradost.quicknovel.mvvm.logError
+import kotlinx.coroutines.runBlocking
 import java.io.*
 import java.net.URL
 import java.net.URLConnection
@@ -30,6 +34,10 @@ const val UPDATE_TIME = 1000
 class InAppUpdater {
     companion object {
         // === IN APP UPDATER ===
+        @Volatile
+        private var isDownloadingUpdate: Boolean = false
+
+        private const val UPDATE_NOTIFICATION_ID = -1
         data class GithubAsset(
             @JsonProperty("name") val name: String,
             @JsonProperty("size") val size: Int, // Size bytes
@@ -119,6 +127,8 @@ class InAppUpdater {
         }
 
         private fun Activity.downloadUpdate(url: String): Boolean {
+            if(isDownloadingUpdate) return false
+            isDownloadingUpdate = true
             var fullResume = false // IF FULL RESUME
             try {
                 // =================== DOWNLOAD POSTERS AND SETUP PATH ===================
@@ -129,7 +139,7 @@ class InAppUpdater {
                 val rFile = File(path)
                 try {
                     rFile.parentFile?.mkdirs()
-                } catch (t: Throwable) {
+                } catch (t: Throwable){
                     logError(t)
                 }
 
@@ -171,6 +181,7 @@ class InAppUpdater {
                 }
                 if (clen <= 0) { // TO SMALL OR INVALID
                     //showNot(0, 0, 0, DownloadType.IsFailed, info)
+                    isDownloadingUpdate = false
                     return false
                 }
 
@@ -182,6 +193,7 @@ class InAppUpdater {
                 val buffer = ByteArray(1024)
                 var count: Int
                 //var lastUpdate = System.currentTimeMillis()
+                var lastUpdateTime = System.currentTimeMillis()
 
                 while (true) {
                     try {
@@ -191,6 +203,41 @@ class InAppUpdater {
                         bytesRead += count
                         bytesPerSec += count
                         output.write(buffer, 0, count)
+
+                        val currentTime = System.currentTimeMillis()
+                        val timeElapsed = currentTime - lastUpdateTime
+                        if (timeElapsed > 1000) {
+                            val progress = bytesRead
+                            val total = clen.toLong()
+
+                            val bps = (bytesPerSec * 1000) / timeElapsed.coerceAtLeast(1)
+                            val eta = if(bps > 0) (total - progress) / bps * 1000 else 0L
+                            bytesPerSec = 0
+                            lastUpdateTime = currentTime
+                            println("bps: $bps | eta: ${eta/1000}s | progress: $progress/$total")
+
+                            runBlocking {
+                                NotificationHelper.createNotification(
+                                    context = this@downloadUpdate,
+                                    source = url,
+                                    id = UPDATE_NOTIFICATION_ID,
+                                    name = "QuickNovel Update",
+                                    stateProgressState = DownloadProgressState(
+                                        state = DownloadState.IsDownloading,
+                                        downloaded = progress,
+                                        progress = progress,
+                                        total = total,
+                                        lastUpdatedMs = lastUpdateTime,
+                                        etaMs = eta
+                                    ),
+                                    progressInBytes = true,
+                                    isActionable = false
+
+                                )
+                            }
+                            lastUpdateTime = currentTime
+                        }
+
                     } catch (t: Throwable) {
                         logError(t)
                         fullResume = true
@@ -207,6 +254,25 @@ class InAppUpdater {
                 output.flush()
                 output.close()
                 input.close()
+                runBlocking {
+                    NotificationHelper.createNotification(
+                        context = this@downloadUpdate,
+                        source = url,
+                        id = UPDATE_NOTIFICATION_ID,
+                        name = "QuickNovel Update",
+                        posterUrl = null,
+                        stateProgressState = DownloadProgressState(
+                            DownloadState.IsDone,
+                            clen.toLong(),
+                            clen.toLong(),
+                            clen.toLong(),
+                            lastUpdateTime,
+                            null),
+                        showNotification = false
+                    )
+                }
+
+                isDownloadingUpdate = false
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                     val contentUri = FileProvider.getUriForFile(
@@ -235,6 +301,7 @@ class InAppUpdater {
 
             } catch (t: Throwable) {
                 logError(t)
+                isDownloadingUpdate = false
                 return false
             }
         }


### PR DESCRIPTION
Added in-app update notifications with progress tracking and refactored `NotificationHelper` to support general-purpose notification creation.

- **In-App Updater**: Added download progress tracking (BPS, ETA) and integrated with `NotificationHelper` to show update status.
- **NotificationHelper**: Refactored `createNotification` to be more modular, allowing its use for both book downloads and app updates.
- **BookDownloader2**: Improved error handling with additional `try-catch` blocks and simplified notification logic.
- **General**: Added a volatile check to prevent multiple concurrent update downloads.