### PR TITLE
Providers and Epubs Fixes

### DIFF
--- a/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
@@ -1925,6 +1925,7 @@ object BookDownloader2 {
         count: Int
     ): Boolean? {
         val originalBitmap = imageXObject.image ?: return null
+        if (originalBitmap.width <= 0 || originalBitmap.height <= 0) return null
         if (!originalBitmap.isRecycled) {
             try {
                 val maxRes = 1200

--- a/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
@@ -50,6 +50,7 @@ import com.lagradost.quicknovel.BookDownloader2Helper.IMPORT_SOURCE_PDF
 import com.lagradost.quicknovel.BookDownloader2Helper.createQuickStream
 import com.lagradost.quicknovel.BookDownloader2Helper.generateId
 import com.lagradost.quicknovel.BookDownloader2Helper.getDirectory
+import com.lagradost.quicknovel.BookDownloader2Helper.getSafeByteArray
 import com.lagradost.quicknovel.CommonActivity.activity
 import com.lagradost.quicknovel.CommonActivity.showToast
 import com.lagradost.quicknovel.DataStore.getSharedPrefs
@@ -93,7 +94,6 @@ import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import me.ag2s.epublib.domain.Author
 import me.ag2s.epublib.domain.EpubBook
-import me.ag2s.epublib.domain.MediaType
 import me.ag2s.epublib.domain.MediaTypes
 import me.ag2s.epublib.domain.Resource
 import me.ag2s.epublib.epub.EpubReader
@@ -105,6 +105,7 @@ import java.io.FileOutputStream
 import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.io.readBytes
 import kotlin.time.Duration.Companion.milliseconds
 
 enum class DownloadActionType {
@@ -200,93 +201,101 @@ object BookDownloader2Helper {
     private fun calculateInSampleSize(options: BitmapFactory.Options, reqWidth: Int, reqHeight: Int): Int {
         val (height: Int, width: Int) = options.outHeight to options.outWidth
         var inSampleSize = 1
-
         if (height > reqHeight || width > reqWidth) {
             val halfHeight = height / 2
             val halfWidth = width / 2
-
             while (halfHeight / inSampleSize >= reqHeight && halfWidth / inSampleSize >= reqWidth) {
                 inSampleSize *= 2
             }
         }
         return inSampleSize
     }
-    private val cachedBitmaps = hashMapOf<String, Bitmap>()
+
+    //to show images
+    /**
+     * Decodes a Bitmap from a File path with a maximum resolution constraint.
+     * It uses inJustDecodeBounds to avoid loading the full image into RAM.
+     */
+    fun decodeSafeBitmap(
+        path: String? = null,
+        data: ByteArray? = null,
+        maxRes: Int = 1200,
+        config: Bitmap.Config = Bitmap.Config.ARGB_8888
+    ): Bitmap?
+    {
+        return try {
+            val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+
+            val finalData = when {
+                path != null -> {
+                    BitmapFactory.decodeFile(path, options)
+                    null
+                }
+                data != null -> {
+                    BitmapFactory.decodeByteArray(data, 0, data.size, options)
+                    data
+                }
+                else -> return null
+            }
+
+            options.inSampleSize = calculateInSampleSize(options, maxRes, maxRes)
+            options.inJustDecodeBounds = false
+            options.inPreferredConfig = config
+
+            when {
+                path != null -> BitmapFactory.decodeFile(path, options)
+                finalData != null -> BitmapFactory.decodeByteArray(finalData, 0, finalData.size, options)
+                else -> null
+            }
+        } catch (e: Exception) {
+            logError(e)
+            null
+        }
+    }
+    /**
+     *  Loads a Bitmap from disk for display.
+     */
+    fun decodeSafeBitmap(path: String, maxRes: Int = 1200): Bitmap? {
+        return decodeSafeBitmap(path = path, maxRes = maxRes, config = Bitmap.Config.ARGB_8888)
+    }
+
+
+    //to save images
+    /**
+     * Checks if a ByteArray image is too large and downsamples it if necessary.
+     * This prevents saving massive bitmaps that crash the Canvas later.
+     */
+    fun getSafeByteArray(data: ByteArray, maxRes: Int = 1200): ByteArray {
+        // If the image is already small, don't waste CPU
+        val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeByteArray(data, 0, data.size, options)
+        if (options.outWidth <= maxRes && options.outHeight <= maxRes) return data
+
+        // Process and re-compress
+        val bitmap = decodeSafeBitmap(data = data, maxRes = maxRes, config = Bitmap.Config.RGB_565) ?: return data
+        val outputStream = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.JPEG, 90, outputStream)
+        val result = outputStream.toByteArray()
+        bitmap.recycle()
+        return result
+    }
+
+    //to get covers
     /**
      * Loads a book img from local storage, downsampling it to prevent memory issues
      * and caching it in memory for fast access.
      */
+    private val cachedBitmaps = hashMapOf<String, Bitmap>()
     fun getCachedBitmap(activity: Activity?, apiName: String, author: String?, name: String): Bitmap? {
         val filePath = getFilenameIMG(sanitizeFilename(apiName), sanitizeFilename(author ?: ""), sanitizeFilename(name))
         cachedBitmaps[filePath]?.let { return it }
 
-        val context = activity ?: return null
-        val file = File(context.filesDir, filePath)
+        val file = File(activity?.filesDir, filePath.trimStart(File.separatorChar))
         if (!file.exists()) return null
 
         return decodeSafeBitmap(file.absolutePath)?.also {
             cachedBitmaps[filePath] = it
         }
-    }
-    /**
-    * Checks if a ByteArray image is too large and downsamples it if necessary.
-    * This prevents saving massive bitmaps that crash the Canvas later.
-    */
-    fun getSafeByteArray(data: ByteArray, maxRes: Int = 1200): ByteArray {
-        try {
-            val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-            BitmapFactory.decodeByteArray(data, 0, data.size, options)
-
-            if (options.outWidth <= maxRes && options.outHeight <= maxRes) return data
-
-            options.inSampleSize = calculateInSampleSize(options, maxRes, maxRes)
-            options.inJustDecodeBounds = false
-            options.inPreferredConfig = Bitmap.Config.RGB_565
-
-            val bitmap = BitmapFactory.decodeByteArray(data, 0, data.size, options) ?: return data
-            val outputStream = ByteArrayOutputStream()
-            bitmap.compress(Bitmap.CompressFormat.JPEG, 90, outputStream)
-            val result = outputStream.toByteArray()
-            bitmap.recycle()
-            return result
-        } catch (e: Exception) { return data }
-    }
-    /**
-     * Decodes a Bitmap from a File path with a maximum resolution constraint.
-     * It uses inJustDecodeBounds to avoid loading the full image into RAM.
-     */
-    fun decodeSafeBitmap(path: String, maxRes: Int = 1200): Bitmap? {
-        return try {
-            val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-            BitmapFactory.decodeFile(path, options)
-
-            options.inSampleSize = calculateInSampleSize(options, maxRes, maxRes)
-            options.inJustDecodeBounds = false
-            options.inPreferredConfig = Bitmap.Config.ARGB_8888
-
-            BitmapFactory.decodeFile(path, options)
-        } catch (e: Exception) {
-            null
-        }
-    }
-
-    /**
-     * Converts any image (File or ByteArray) into a safe, downsampled Resource for Epublib.
-     * This prevents the EpubBook object from holding "RAM bombs".
-     */
-    fun createSafeResource(file: File, maxRes: Int = 1200): Resource? {
-        if (!file.exists()) return null
-
-        // Use decodeSafeBitmap to get a resized version
-        val bitmap = decodeSafeBitmap(file.absolutePath, maxRes) ?: return null
-
-        return try {
-            val outStream = ByteArrayOutputStream()
-            bitmap.compress(Bitmap.CompressFormat.JPEG, 85, outStream)
-            val data = outStream.toByteArray()
-            bitmap.recycle()
-            Resource(data, file.name)
-        } catch (e: Exception) { null }
     }
     fun generateId(apiName: String, author: String?, name: String): Int {
         val sApiname = sanitizeFilename(apiName)
@@ -798,8 +807,9 @@ object BookDownloader2Helper {
                 LOCAL_EPUB
             )
             if (epubFile.exists() && epubFile.length() > LOCAL_EPUB_MIN_SIZE) {
-                fileStream.write(epubFile.readBytes())
-
+                epubFile.inputStream().use { input ->
+                    input.copyTo(fileStream)
+                }
                 setKey(DOWNLOAD_EPUB_SIZE, id.toString(), 1)
             } else {
 
@@ -819,9 +829,7 @@ object BookDownloader2Helper {
                     activity.filesDir.toString() + getFilenameIMG(sApiName, sAuthor, sName)
                 val pFile = File(posterFilepath)
                 if (pFile.exists()) {
-                    BookDownloader2Helper.createSafeResource(pFile)?.let { res ->
-                        book.coverImage = res
-                    }
+                    book.coverImage = Resource(getSafeByteArray(pFile.readBytes()), pFile.name)
                 }
 
                 val stripHtml = activity.getStripHtml()
@@ -2137,7 +2145,7 @@ object BookDownloader2 {
                 tempFolder.listFiles()?.let { files ->
                     for ((i, file) in files.withIndex()) {
                         if (file.name.contains("img_")) {
-                            val res = BookDownloader2Helper.createSafeResource(file) ?: continue
+                            val res = Resource(getSafeByteArray(file.readBytes()), file.name)
                             book.addResource(res)
                             if (i == 0) book.coverImage = res
                         }

--- a/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
@@ -192,35 +192,70 @@ object BookDownloader2Helper {
     }
 
     private val cachedBitmaps = hashMapOf<String, Bitmap>()
+    /**
+     * Loads a book img from local storage, downsampling it to prevent memory issues
+     * and caching it in memory for fast access.
+     */
     fun getCachedBitmap(
         activity: Activity?,
         apiName: String,
         author: String?,
         name: String
     ): Bitmap? {
-        try {
-            val filePath = getFilenameIMG(
-                sanitizeFilename(apiName),
-                sanitizeFilename(author ?: ""),
-                sanitizeFilename(name)
-            )
+        val filePath = getFilenameIMG(
+            sanitizeFilename(apiName),
+            sanitizeFilename(author ?: ""),
+            sanitizeFilename(name)
+        )
+        cachedBitmaps[filePath]?.let { return it }
+        val context = activity ?: return null
 
-            val existing = cachedBitmaps[filePath]
-            if (existing != null) return existing
-            if (activity == null) return null
+        return try {
+            val file = File(context.filesDir, filePath)
 
-            val file = activity.filesDir.toString() + filePath
-            val data = File(file).readBytes()
-            val bitmap = BitmapFactory.decodeByteArray(data, 0, data.size)
-            cachedBitmaps[filePath] = bitmap
+            // Decode dimensions to calculate sample size
+            val options = BitmapFactory.Options().apply {
+                //start only reading size
+                inJustDecodeBounds = true
+            }
 
-            return bitmap
-        } catch (t: Throwable) {
-            logError(t)
-            return null
+            //get img
+            BitmapFactory.decodeFile(file.absolutePath, options)
+
+            // Set downsampling to avoid "Canvas: drawing too large bitmap" crash
+            // We target ~1200px which is more than enough for high-quality images
+            options.inSampleSize = calculateInSampleSize(options, 1200, 1200)
+            options.inJustDecodeBounds = false
+            options.inPreferredConfig = Bitmap.Config.ARGB_8888
+
+            // Decode the actual bitmap and cache it
+            BitmapFactory.decodeFile(file.absolutePath, options)?.also {
+                cachedBitmaps[filePath] = it
+            }
+        } catch (e: Exception) {
+            logError(e)
+            null
         }
     }
 
+    /**
+     * Calculates the largest power-of-two inSampleSize that keeps the image
+     * dimensions larger than or equal to the requested dimensions.
+     */
+    private fun calculateInSampleSize(options: BitmapFactory.Options, reqWidth: Int, reqHeight: Int): Int {
+        val (height: Int, width: Int) = options.outHeight to options.outWidth
+        var inSampleSize = 1
+
+        if (height > reqHeight || width > reqWidth) {
+            val halfHeight = height / 2
+            val halfWidth = width / 2
+
+            while (halfHeight / inSampleSize >= reqHeight && halfWidth / inSampleSize >= reqWidth) {
+                inSampleSize *= 2
+            }
+        }
+        return inSampleSize
+    }
     fun generateId(apiName: String, author: String?, name: String): Int {
         val sApiname = sanitizeFilename(apiName)
         val sAuthor = if (author == null) "" else sanitizeFilename(author)

--- a/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
@@ -30,6 +30,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.toBitmap
+import androidx.core.graphics.scale
 import androidx.core.net.toUri
 import androidx.preference.PreferenceManager
 import coil3.Extras
@@ -191,52 +192,6 @@ object BookDownloader2Helper {
         return "${getDirectory(apiName, author, name)}${fs}poster.jpg".replace("$fs$fs", "$fs")
     }
 
-    private val cachedBitmaps = hashMapOf<String, Bitmap>()
-    /**
-     * Loads a book img from local storage, downsampling it to prevent memory issues
-     * and caching it in memory for fast access.
-     */
-    fun getCachedBitmap(
-        activity: Activity?,
-        apiName: String,
-        author: String?,
-        name: String
-    ): Bitmap? {
-        val filePath = getFilenameIMG(
-            sanitizeFilename(apiName),
-            sanitizeFilename(author ?: ""),
-            sanitizeFilename(name)
-        )
-        cachedBitmaps[filePath]?.let { return it }
-        val context = activity ?: return null
-
-        return try {
-            val file = File(context.filesDir, filePath)
-
-            // Decode dimensions to calculate sample size
-            val options = BitmapFactory.Options().apply {
-                //start only reading size
-                inJustDecodeBounds = true
-            }
-
-            //get img
-            BitmapFactory.decodeFile(file.absolutePath, options)
-
-            // Set downsampling to avoid "Canvas: drawing too large bitmap" crash
-            // We target ~1200px which is more than enough for high-quality images
-            options.inSampleSize = calculateInSampleSize(options, 1200, 1200)
-            options.inJustDecodeBounds = false
-            options.inPreferredConfig = Bitmap.Config.ARGB_8888
-
-            // Decode the actual bitmap and cache it
-            BitmapFactory.decodeFile(file.absolutePath, options)?.also {
-                cachedBitmaps[filePath] = it
-            }
-        } catch (e: Exception) {
-            logError(e)
-            null
-        }
-    }
 
     /**
      * Calculates the largest power-of-two inSampleSize that keeps the image
@@ -255,6 +210,83 @@ object BookDownloader2Helper {
             }
         }
         return inSampleSize
+    }
+    private val cachedBitmaps = hashMapOf<String, Bitmap>()
+    /**
+     * Loads a book img from local storage, downsampling it to prevent memory issues
+     * and caching it in memory for fast access.
+     */
+    fun getCachedBitmap(activity: Activity?, apiName: String, author: String?, name: String): Bitmap? {
+        val filePath = getFilenameIMG(sanitizeFilename(apiName), sanitizeFilename(author ?: ""), sanitizeFilename(name))
+        cachedBitmaps[filePath]?.let { return it }
+
+        val context = activity ?: return null
+        val file = File(context.filesDir, filePath)
+        if (!file.exists()) return null
+
+        return decodeSafeBitmap(file.absolutePath)?.also {
+            cachedBitmaps[filePath] = it
+        }
+    }
+    /**
+    * Checks if a ByteArray image is too large and downsamples it if necessary.
+    * This prevents saving massive bitmaps that crash the Canvas later.
+    */
+    fun getSafeByteArray(data: ByteArray, maxRes: Int = 1200): ByteArray {
+        try {
+            val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            BitmapFactory.decodeByteArray(data, 0, data.size, options)
+
+            if (options.outWidth <= maxRes && options.outHeight <= maxRes) return data
+
+            options.inSampleSize = calculateInSampleSize(options, maxRes, maxRes)
+            options.inJustDecodeBounds = false
+            options.inPreferredConfig = Bitmap.Config.RGB_565
+
+            val bitmap = BitmapFactory.decodeByteArray(data, 0, data.size, options) ?: return data
+            val outputStream = ByteArrayOutputStream()
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 90, outputStream)
+            val result = outputStream.toByteArray()
+            bitmap.recycle()
+            return result
+        } catch (e: Exception) { return data }
+    }
+    /**
+     * Decodes a Bitmap from a File path with a maximum resolution constraint.
+     * It uses inJustDecodeBounds to avoid loading the full image into RAM.
+     */
+    fun decodeSafeBitmap(path: String, maxRes: Int = 1200): Bitmap? {
+        return try {
+            val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            BitmapFactory.decodeFile(path, options)
+
+            options.inSampleSize = calculateInSampleSize(options, maxRes, maxRes)
+            options.inJustDecodeBounds = false
+            options.inPreferredConfig = Bitmap.Config.ARGB_8888
+
+            BitmapFactory.decodeFile(path, options)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Converts any image (File or ByteArray) into a safe, downsampled Resource for Epublib.
+     * This prevents the EpubBook object from holding "RAM bombs".
+     */
+    fun createSafeResource(file: File, maxRes: Int = 1200): Resource? {
+        if (!file.exists()) return null
+
+        // Use decodeSafeBitmap to get a resized version
+        val bitmap = decodeSafeBitmap(file.absolutePath, maxRes) ?: return null
+
+        return try {
+            val outStream = ByteArrayOutputStream()
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 85, outStream)
+            val data = outStream.toByteArray()
+            bitmap.recycle()
+            Resource(data, file.name)
+        } catch (e: Exception) { null }
     }
     fun generateId(apiName: String, author: String?, name: String): Int {
         val sApiname = sanitizeFilename(apiName)
@@ -787,7 +819,9 @@ object BookDownloader2Helper {
                     activity.filesDir.toString() + getFilenameIMG(sApiName, sAuthor, sName)
                 val pFile = File(posterFilepath)
                 if (pFile.exists()) {
-                    book.coverImage = Resource(pFile.readBytes(), MediaType("cover", ".jpg"))
+                    BookDownloader2Helper.createSafeResource(pFile)?.let { res ->
+                        book.coverImage = res
+                    }
                 }
 
                 val stripHtml = activity.getStripHtml()
@@ -1888,13 +1922,26 @@ object BookDownloader2 {
         filesDir: File,
         count: Int
     ): Boolean? {
-        val bitmap = imageXObject.image
-        if (!bitmap.isRecycled) {
+        val originalBitmap = imageXObject.image ?: return null
+        if (!originalBitmap.isRecycled) {
             try {
-                val outStream = ByteArrayOutputStream()
+                val maxRes = 1200
+                val shouldScale = originalBitmap.width > maxRes || originalBitmap.height > maxRes
 
-                //get image compressed as byteArray
-                bitmap.compress(Bitmap.CompressFormat.JPEG, 80, outStream)
+                val finalBitmap = if (shouldScale) {
+                    val ratio = originalBitmap.width.toFloat() / originalBitmap.height.toFloat()
+                    val targetW = if (ratio > 1) maxRes else (maxRes * ratio).toInt()
+                    val targetH = if (ratio > 1) (maxRes / ratio).toInt() else maxRes
+
+                    originalBitmap.scale(targetW, targetH).also {
+                        originalBitmap.recycle()
+                    }
+                } else {
+                    originalBitmap
+                }
+
+                val outStream = ByteArrayOutputStream()
+                finalBitmap.compress(Bitmap.CompressFormat.JPEG, 85, outStream)
                 val imgBytes = outStream.toByteArray()
 
                 // only over NKB images
@@ -1913,13 +1960,11 @@ object BookDownloader2 {
                             }
                         }
                     }
-
+                    finalBitmap.recycle()
                     return true
                 }
             } catch (e: Exception) {
                 logError(e)
-            } finally {
-                if (!bitmap.isRecycled) bitmap.recycle() //delete from ram
             }
         }
         return null
@@ -2089,13 +2134,14 @@ object BookDownloader2 {
 
             if (currentState == DownloadState.IsDone) {
                 //add imgs to book
-                tempFolder.listFiles()?.let {
-                    for ((i, file) in it.withIndex())
+                tempFolder.listFiles()?.let { files ->
+                    for ((i, file) in files.withIndex()) {
                         if (file.name.contains("img_")) {
-                            val res = Resource(file.readBytes(), file.name)
+                            val res = BookDownloader2Helper.createSafeResource(file) ?: continue
                             book.addResource(res)
                             if (i == 0) book.coverImage = res
                         }
+                    }
                 }
 
                 //use twice, to sort chapters
@@ -2287,7 +2333,9 @@ object BookDownloader2 {
                                         )
                                     }
                         }?.let { entry ->
-                            coverBytes = zipFile.getInputStream(entry).use { it.readBytes() }
+                            val rawBytes = zipFile.getInputStream(entry).use { it.readBytes() }
+                            // Downsample the image before assigning it to coverBytes
+                            coverBytes = BookDownloader2Helper.getSafeByteArray(rawBytes)
                         }
                 }
 

--- a/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
@@ -348,21 +348,24 @@ object BookDownloader2Helper {
             return false
         }
 
-        val relativePath = (Environment.DIRECTORY_DOWNLOADS + "${fs}Epub${fs}")
         val displayName = "${sanitizeFilename(name)}.epub"
 
-        if (isScopedStorage()) {
-            val cr = activity.contentResolver ?: return false
-            val fileUri =
-                cr.getExistingDownloadUriOrNullQ(relativePath, displayName) ?: return false
-            val fileLength = cr.getFileLength(fileUri) ?: return false
-            return fileLength != 0L
-        } else {
-            val normalPath =
-                "${Environment.getExternalStorageDirectory()}${fs}$relativePath$displayName"
+        return try {
+            val (baseDir, _) = activity.getBasePath()
 
-            val bookFile = File(normalPath)
-            return bookFile.exists()
+            val epubFile = baseDir?.findFile(displayName)
+
+            if (epubFile != null && epubFile.exists() == true) {
+
+                activity.contentResolver.openFileDescriptor(epubFile.uriOrThrow(), "r")?.use {
+                    it.statSize > 0
+                } ?: false
+            } else {
+                false
+            }
+        } catch (e: Exception) {
+            com.lagradost.safefile.logError(e)
+            false
         }
     }
 

--- a/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
@@ -348,24 +348,15 @@ object BookDownloader2Helper {
             return false
         }
 
-        val displayName = "${sanitizeFilename(name)}.epub"
+        try {
+            val subDir =
+                activity.getBasePath().first ?: getDefaultDir(activity) ?: throw IOException("No file")
+            val displayName = "${sanitizeFilename(name)}.epub"
+            val foundFile = subDir.findFileOrThrow(displayName)
 
-        return try {
-            val (baseDir, _) = activity.getBasePath()
-
-            val epubFile = baseDir?.findFile(displayName)
-
-            if (epubFile != null && epubFile.exists() == true) {
-
-                activity.contentResolver.openFileDescriptor(epubFile.uriOrThrow(), "r")?.use {
-                    it.statSize > 0
-                } ?: false
-            } else {
-                false
-            }
-        } catch (e: Exception) {
-            com.lagradost.safefile.logError(e)
-            false
+            return foundFile.uri() != null
+        } catch (_ : Throwable) {
+            return false
         }
     }
 

--- a/app/src/main/java/com/lagradost/quicknovel/MainAPI.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/MainAPI.kt
@@ -174,12 +174,12 @@ data class HeadMainPageResponse(
 
 data class UserReview(
     val review: String,
-    val reviewTitle: String?,
-    val username: String?,
-    val reviewDate: String?,
-    val avatarUrl: String?,
-    val rating: Int?,
-    val ratings: List<Pair<Int, String>>?,
+    val reviewTitle: String? = null,
+    val username: String? = null,
+    val reviewDate: String? = null,
+    val avatarUrl: String? = null,
+    val rating: Int? = null,
+    val ratings: List<Pair<Int, String>>? = null,
 )
 /*
 data class MainPageResponse(

--- a/app/src/main/java/com/lagradost/quicknovel/ReadActivityViewModel.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/ReadActivityViewModel.kt
@@ -96,6 +96,7 @@ import me.ag2s.epublib.util.zip.AndroidZipFile
 import org.commonmark.node.Node
 import org.jsoup.Jsoup
 import java.io.File
+import java.io.InputStream
 import java.net.URLDecoder
 import java.security.MessageDigest
 import java.util.Locale
@@ -175,17 +176,19 @@ abstract class AbstractBook {
     abstract fun getLoadingStatus(index: Int): String?
 
     @Throws
-    open fun loadImage(image: String): ByteArray? {
-        return null
-    }
+    open fun loadImage(image: String): InputStream? = null
 
     fun loadImageBitmap(image: String): Bitmap? {
-        try {
-            val data = this.loadImage(image) ?: return null
-            return BitmapFactory.decodeByteArray(data, 0, data.size)
+        return try {
+            // read file and not save
+            val stream = this.loadImage(image)
+            return if (stream != null) {
+                 BookDownloader2Helper.decodeSafeBitmap(data = stream.readBytes())
+            }
+            else null
         } catch (t: Throwable) {
             logError(t)
-            return null
+            null
         }
     }
 
@@ -330,17 +333,11 @@ class RegularBook(val data: EpubBook) : AbstractBook() {
         return listOfNotNull(author.firstname, author.lastname).joinToString(" ").ifBlank { null }
     }
 
-    override fun loadImage(image: String): ByteArray? {
+    override fun loadImage(image: String): InputStream? {
         val decodedImage = try { URLDecoder.decode(image, "UTF-8") } catch (e: Exception) { image }
-
-        data.resources.resourceMap[decodedImage]?.data?.let { return it }
-        data.resources.resourceMap[image]?.data?.let { return it }
-
-        val fileName = decodedImage.substringAfterLast("/")
-        return data.resources.resourceMap.values.find {
-            val entryName = it.href.substringAfterLast("/")
-            entryName.equals(fileName, ignoreCase = true)
-        }?.data
+        val res = data.resources.resourceMap[decodedImage]
+            ?: data.resources.resourceMap[image]
+        return res?.inputStream
     }
 
     override fun size(): Int = allTocReferences.size

--- a/app/src/main/java/com/lagradost/quicknovel/providers/AnnasArchive.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/AnnasArchive.kt
@@ -1,5 +1,11 @@
 package com.lagradost.quicknovel.providers
 
+import android.annotation.SuppressLint
+import android.webkit.*
+import com.lagradost.quicknovel.BaseApplication.Companion.context
+import com.lagradost.quicknovel.util.Coroutines.main
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.withTimeoutOrNull
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.quicknovel.DownloadExtractLink
 import com.lagradost.quicknovel.DownloadLink
@@ -9,6 +15,7 @@ import com.lagradost.quicknovel.LoadResponse
 import com.lagradost.quicknovel.MainAPI
 import com.lagradost.quicknovel.R
 import com.lagradost.quicknovel.SearchResponse
+import com.lagradost.quicknovel.USER_AGENT
 import com.lagradost.quicknovel.fixUrlNull
 import com.lagradost.quicknovel.newEpubResponse
 import com.lagradost.quicknovel.newSearchResponse
@@ -109,8 +116,8 @@ class AnnasArchive : MainAPI() {
     }
 
 
-    private fun extract(url: String, name: String): DownloadLinkType {
-        return if (url.contains(".epub")) {
+    private fun extract(url: String, name: String, force:Boolean = false): DownloadLinkType {
+        return if (url.contains(".epub") || force) {
             DownloadLink(
                 url = url,
                 name = name,
@@ -124,57 +131,29 @@ class AnnasArchive : MainAPI() {
         }
     }
 
-    private suspend fun loadFromJsonUrl(md5: String): LoadResponse {
-        return app.get("$mainUrl/db/md5/$md5.json").parsed<AnnasArchiveRoot>().let { root ->
-            newEpubResponse(
-                name = root.fileUnifiedData?.titleBest ?: root.additional.topBox.title
-                ?: root.fileUnifiedData?.titleAdditional!!.first(),
-                url = "$mainUrl/md5/$md5",
-                links = root.additional.downloadUrls.mapNotNull { list ->
-                    val name = list.getOrNull(0) ?: return@mapNotNull null
-                    val link = list.getOrNull(1) ?: return@mapNotNull null
-                    extract(link, name)
-                }) {
-                author = root.fileUnifiedData?.authorBest ?: root.additional.topBox.author
-                        ?: root.fileUnifiedData?.authorAdditional?.firstOrNull()
-                posterUrl = root.fileUnifiedData?.coverUrlBest ?: root.additional.topBox.coverUrl
-                        ?: root.fileUnifiedData?.coverUrlAdditional?.firstOrNull()
-                synopsis = root.additional.topBox.description
-            }
-        }
-    }
-
     override suspend fun load(url: String): LoadResponse {
-        /* cloudflare
-        val md5Prefix = "$mainUrl/md5/"
-        if (url.startsWith(md5Prefix)) {
-            try {
-                return loadFromJsonUrl(url.removePrefix(md5Prefix))
-            } catch (t: Throwable) {
-                logError(t)
-            }
-        }*/
-
-        // backup non json parser
         val document = app.get(url).document
+        var slowLink: String? = null
 
         return newEpubResponse(
             name = document.selectFirst("div.text-2xl")?.ownText()!!,
             url = url,
-            links = document.select("ul.mb-4 > li > a.js-download-link").mapNotNull { element ->
-                val link = fixUrlNull(element.attr("href")) ?: return@mapNotNull null
-                // member
-                if (link.contains("fast_download")) {
-                    return@mapNotNull null
+            links = document.select("ul.mb-4 > li").mapNotNull { element ->
+                val link = fixUrlNull(element.selectFirst("a.js-download-link")?.attr("href")) ?: return@mapNotNull null
+
+                if (link.contains("fast_download")) return@mapNotNull null
+
+                // Cambio aquí: Usamos el WebView para el link de espera
+                if (element.text().contains("no waitlist")) {
+                    if (slowLink == null) {
+                        // Llamamos a nuestra nueva función
+                        slowLink = getSlowLinkWithWebView(link)
+                        println("consiguio el link?: $slowLink")
+                    }
+                    return@mapNotNull if (slowLink != null) extract(slowLink!!, element.text(), true) else null
                 }
-                // cloudflare
-                if (link.contains("slow_download")) {
-                    return@mapNotNull null
-                }
-                // no idea why this is in the js dl link
-                if (link.endsWith("/datasets")) {
-                    return@mapNotNull null
-                }
+
+                if (link.endsWith("/datasets")) return@mapNotNull null
                 extract(link, element.text())
             }) {
             posterUrl = document.selectFirst("main > div > div > div > div > div > img")?.attr("src")
@@ -183,117 +162,71 @@ class AnnasArchive : MainAPI() {
         }
     }
 
-    // ================================ JSON ================================
-    data class AnnasArchiveRoot(
-        /*@JsonProperty("///md5") var ___md5: ArrayList<String> = arrayListOf(),
-        @JsonProperty("md5") var md5: String? = null,
-        @JsonProperty("///lgrsnf_book") var ___lgrsnfBook: String? = null,
-        @JsonProperty("lgrsnf_book") var lgrsnfBook: String? = null,
-        @JsonProperty("///lgrsfic_book") var ___lgrsficBook: String? = null,
-        @JsonProperty("lgrsfic_book") var lgrsficBook: String? = null,
-        @JsonProperty("///lgli_file") var ___lgliFile: String? = null,
-        @JsonProperty("lgli_file") var lgliFile: LgliFile? = LgliFile(),
-        @JsonProperty("///zlib_book") var ___zlibBook: String? = null,
-        @JsonProperty("zlib_book") var zlibBook: ZlibBook? = ZlibBook(),
-        @JsonProperty("///aa_lgli_comics_2022_08_file") var ___aaLgliComics202208File: ArrayList<String> = arrayListOf(),
-        @JsonProperty("aa_lgli_comics_2022_08_file") var aaLgliComics202208File: String? = null,
-        @JsonProperty("///ipfs_infos") var ___ipfsInfos: String? = null,
-        @JsonProperty("ipfs_infos") var ipfsInfos: ArrayList<String> = arrayListOf(),
-        @JsonProperty("///file_unified_data") var ___fileUnifiedData: String? = null,
-        @JsonProperty("///search_only_fields") var ___searchOnlyFields: String? = null,
-        @JsonProperty("search_only_fields") var searchOnlyFields: SearchOnlyFields? = SearchOnlyFields(),
-        @JsonProperty("///additional") var ___additional: String? = null,*/
-        @JsonProperty("additional") var additional: Additional = Additional(),
-        @JsonProperty("file_unified_data") var fileUnifiedData: FileUnifiedData? = FileUnifiedData(),
-    )
+    @SuppressLint("SetJavaScriptEnabled")
+    /*
+        Before you guys kill me, I really, really tried every other way.
+        I heavily modified CloudflareKiller and DDoS-Guard still beat me—they have impressive
+        security for a pirate site! As a last resort, I mimicked the CloudflareKiller logic
+        and used a WebView directly to get the link I needed. This was the only solution that
+        actually worked. I think Anna’s Archive is too important to lose, so I felt using a heavy
+        measure like a WebView was worth it to keep all those books available.
+    * */
+    private suspend fun getSlowLinkWithWebView(url: String): String? {
+        val deferred = CompletableDeferred<String?>()
 
-    /*data class LgliFile(
-        @JsonProperty("f_id") var fId: Int? = null,
-        @JsonProperty("md5") var md5: String? = null,
-        @JsonProperty("libgen_topic") var libgenTopic: String? = null,
-        @JsonProperty("libgen_id") var libgenId: Int? = null,
-        @JsonProperty("fiction_id") var fictionId: Int? = null,
-        @JsonProperty("fiction_rus_id") var fictionRusId: Int? = null,
-        @JsonProperty("comics_id") var comicsId: Int? = null,
-        @JsonProperty("scimag_id") var scimagId: Int? = null,
-        @JsonProperty("standarts_id") var standartsId: Int? = null,
-        @JsonProperty("magz_id") var magzId: Int? = null,
-        @JsonProperty("scimag_archive_path") var scimagArchivePath: String? = null
-    )
+        main {
+            val ctx = context.let { ctx->
+                if(ctx == null){
+                    deferred.complete(null)
+                    return@main
+                }
+                else ctx
+            }
+            val webView = WebView(ctx)
+            webView.settings.javaScriptEnabled = true
+            webView.settings.domStorageEnabled = true
+            webView.settings.userAgentString = USER_AGENT
 
+            //bridge between JavaScript and kotlin. very important.
+            webView.addJavascriptInterface(object {
+                @JavascriptInterface
+                //this will be called in JavaScript text bellow
+                fun onElementFound(html: String) {
+                    deferred.complete(html)
+                }
+            }, "NativeAndroid")
 
-    data class ZlibBook(
-        @JsonProperty("zlibrary_id") var zlibraryId: Int? = null,
-        @JsonProperty("md5") var md5: String? = null,
-        @JsonProperty("md5_reported") var md5Reported: String? = null,
-        @JsonProperty("filesize") var filesize: Int? = null,
-        @JsonProperty("filesize_reported") var filesizeReported: Int? = null,
-        @JsonProperty("in_libgen") var inLibgen: Int? = null,
-        @JsonProperty("pilimi_torrent") var pilimiTorrent: String? = null
-    )
+            //this will check and look for the book url
+            webView.webViewClient = object : WebViewClient() {
+                override fun onPageFinished(view: WebView?, url: String?) {
+                    val js = """
+                        (function() {
+                            var checkInterval = setInterval(function() {
+                                // selector específico: el span dentro del párrafo con clase mb-4
+                                var element = document.querySelector("main > div > p.mb-4.text-xs > span > span");
+                                if (element && element.innerText.trim().length > 0) {
+                                    clearInterval(checkInterval);
+                                    NativeAndroid.onElementFound(element.innerText.trim());
+                                }
+                            }, 1000);
+                        })();
+                    """.trimIndent()
+                    view?.evaluateJavascript(js, null)
+                }
+            }
 
+            //start loading the page
+            webView.loadUrl(url)
 
+            withTimeoutOrNull(45000) {
+                deferred.await()
+                main {
+                    webView.stopLoading()
+                    webView.destroy()
+                }
+            }
+        }
 
-    data class SearchOnlyFields(
-        @JsonProperty("search_text") var searchText: String? = null,
-        @JsonProperty("score_base") var scoreBase: Int? = null
-    )*/
-
-    data class FileUnifiedData(
-        @JsonProperty("original_filename_best") var originalFilenameBest: String? = null,
-        @JsonProperty("original_filename_additional") var originalFilenameAdditional: ArrayList<String> = arrayListOf(),
-        @JsonProperty("original_filename_best_name_only") var originalFilenameBestNameOnly: String? = null,
-        @JsonProperty("cover_url_best") var coverUrlBest: String? = null,
-        @JsonProperty("cover_url_additional") var coverUrlAdditional: ArrayList<String> = arrayListOf(),
-        @JsonProperty("extension_best") var extensionBest: String? = null,
-        @JsonProperty("extension_additional") var extensionAdditional: ArrayList<String> = arrayListOf(),
-        @JsonProperty("filesize_best") var filesizeBest: Int? = null,
-        @JsonProperty("filesize_additional") var filesizeAdditional: ArrayList<String> = arrayListOf(),
-        @JsonProperty("title_best") var titleBest: String? = null,
-        @JsonProperty("title_additional") var titleAdditional: ArrayList<String> = arrayListOf(),
-        @JsonProperty("author_best") var authorBest: String? = null,
-        @JsonProperty("author_additional") var authorAdditional: ArrayList<String> = arrayListOf(),
-        @JsonProperty("publisher_best") var publisherBest: String? = null,
-        @JsonProperty("publisher_additional") var publisherAdditional: ArrayList<String> = arrayListOf(),
-        @JsonProperty("edition_varia_best") var editionVariaBest: String? = null,
-        @JsonProperty("edition_varia_additional") var editionVariaAdditional: ArrayList<String> = arrayListOf(),
-        @JsonProperty("year_best") var yearBest: String? = null,
-        @JsonProperty("year_additional") var yearAdditional: ArrayList<String> = arrayListOf(),
-        @JsonProperty("comments_best") var commentsBest: String? = null,
-        @JsonProperty("comments_additional") var commentsAdditional: ArrayList<String> = arrayListOf(),
-        @JsonProperty("stripped_description_best") var strippedDescriptionBest: String? = null,
-        @JsonProperty("stripped_description_additional") var strippedDescriptionAdditional: ArrayList<String> = arrayListOf(),
-        @JsonProperty("language_codes") var languageCodes: ArrayList<String> = arrayListOf(),
-        @JsonProperty("most_likely_language_code") var mostLikelyLanguageCode: String? = null,
-        @JsonProperty("sanitized_isbns") var sanitizedIsbns: ArrayList<String> = arrayListOf(),
-        @JsonProperty("asin_multiple") var asinMultiple: ArrayList<String> = arrayListOf(),
-        @JsonProperty("googlebookid_multiple") var googlebookidMultiple: ArrayList<String> = arrayListOf(),
-        @JsonProperty("openlibraryid_multiple") var openlibraryidMultiple: ArrayList<String> = arrayListOf(),
-        @JsonProperty("doi_multiple") var doiMultiple: ArrayList<String> = arrayListOf(),
-        @JsonProperty("problems") var problems: ArrayList<String> = arrayListOf(),
-        @JsonProperty("content_type") var contentType: String? = null,
-        @JsonProperty("has_aa_downloads") var hasAaDownloads: Int? = null,
-        @JsonProperty("has_aa_exclusive_downloads") var hasAaExclusiveDownloads: Int? = null
-    )
-
-    data class TopBox(
-        @JsonProperty("meta_information") var metaInformation: ArrayList<String> = arrayListOf(),
-        @JsonProperty("cover_url") var coverUrl: String? = null,
-        @JsonProperty("top_row") var topRow: String? = null,
-        @JsonProperty("title") var title: String? = null,
-        @JsonProperty("publisher_and_edition") var publisherAndEdition: String? = null,
-        @JsonProperty("author") var author: String? = null,
-        @JsonProperty("description") var description: String? = null
-    )
-
-
-    data class Additional(
-        //@JsonProperty("most_likely_language_name") var mostLikelyLanguageName: String? = null,
-        @JsonProperty("top_box") var topBox: TopBox = TopBox(),
-        @JsonProperty("filename") var filename: String? = null,
-        //@JsonProperty("isbns_rich") var isbnsRich: ArrayList<ArrayList<String>> = arrayListOf(),
-        @JsonProperty("download_urls") var downloadUrls: ArrayList<ArrayList<String>> = arrayListOf(),
-        //@JsonProperty("has_aa_downloads") var hasAaDownloads: Int? = null,
-        //@JsonProperty("has_aa_exclusive_downloads") var hasAaExclusiveDownloads: Int? = null
-    )
+        return withTimeoutOrNull(46000) { deferred.await() }
+    }
 }

--- a/app/src/main/java/com/lagradost/quicknovel/providers/DevilNovelsProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/DevilNovelsProvider.kt
@@ -10,9 +10,12 @@ import com.lagradost.quicknovel.MainActivity.Companion.app
 import com.lagradost.quicknovel.R
 import com.lagradost.quicknovel.SearchResponse
 import com.lagradost.quicknovel.USER_AGENT
+import com.lagradost.quicknovel.fixUrlNull
 import com.lagradost.quicknovel.newChapterData
 import com.lagradost.quicknovel.newSearchResponse
 import com.lagradost.quicknovel.newStreamResponse
+import com.lagradost.quicknovel.providers.NovelFireProvider.RelatedResponse
+import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import kotlin.jvm.Throws
 
@@ -63,6 +66,20 @@ class DevilNovelsProvider : MainAPI() {
         ).parsed<GetFirstPageChaptersResponse>()
     }
 
+    private fun getRelated(document: Document): List<SearchResponse> {
+        return document.select("div.nv-related-grid a").mapNotNull { element ->
+            val href = element.attr("href") ?: return@mapNotNull null
+            val title = element.selectFirst("div.nv-related-name")?.text() ?: return@mapNotNull null
+            newSearchResponse(
+                name = title,
+                url = href
+            ) {
+                posterUrl = fixUrlNull(
+                    element.selectFirst("img")?.attr("src")
+                )
+            }
+        }
+    }
     override suspend fun load(url: String): LoadResponse {
         val document = app.get(url).document
 
@@ -90,6 +107,7 @@ class DevilNovelsProvider : MainAPI() {
             this.author = document.selectFirst("#nvt-sinopsis > div > p:nth-child(3)")?.ownText()
             this.tags = document.selectFirst("#nvt-sinopsis > div > p:nth-child(5)")?.text()
                 ?.replace("Géneros: ", "")?.split(",")?.map { it.trim() }
+            related = getRelated(document)
         }
     }
 

--- a/app/src/main/java/com/lagradost/quicknovel/providers/FenrirRealProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/FenrirRealProvider.kt
@@ -12,9 +12,6 @@ import com.lagradost.quicknovel.setStatus
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.quicknovel.UserReview
 import com.lagradost.quicknovel.newChapterData
-import com.lagradost.quicknovel.providers.NovelFireProvider.PostsResponse
-import com.lagradost.quicknovel.providers.NovelFireProvider.RelatedResponse
-import org.jsoup.Jsoup
 import kotlin.collections.map
 
 class FenrirRealProvider:  MainAPI() {
@@ -25,6 +22,7 @@ class FenrirRealProvider:  MainAPI() {
     //I don't know why, but this fixes the timeout issue for this provider
     override val rateLimitTime = 3000L
     override val hasReviews = true
+    override val usesCloudFlareKiller = true
     var libraryId = ""
 
     override val mainCategories = listOf(

--- a/app/src/main/java/com/lagradost/quicknovel/providers/FenrirRealProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/FenrirRealProvider.kt
@@ -10,7 +10,11 @@ import com.lagradost.quicknovel.newSearchResponse
 import com.lagradost.quicknovel.newStreamResponse
 import com.lagradost.quicknovel.setStatus
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.lagradost.quicknovel.UserReview
 import com.lagradost.quicknovel.newChapterData
+import com.lagradost.quicknovel.providers.NovelFireProvider.PostsResponse
+import com.lagradost.quicknovel.providers.NovelFireProvider.RelatedResponse
+import org.jsoup.Jsoup
 import kotlin.collections.map
 
 class FenrirRealProvider:  MainAPI() {
@@ -20,6 +24,8 @@ class FenrirRealProvider:  MainAPI() {
     override val hasMainPage = true
     //I don't know why, but this fixes the timeout issue for this provider
     override val rateLimitTime = 3000L
+    override val hasReviews = true
+    var libraryId = ""
 
     override val mainCategories = listOf(
         "All" to "any",
@@ -95,12 +101,28 @@ class FenrirRealProvider:  MainAPI() {
         return HeadMainPageResponse(url, returnValue)
     }
 
-
+    suspend fun getRelated(url:String): List<SearchResponse> {
+        val name = url.substringAfter("/series/").removeSuffix("/")
+        val url = "$mainUrl/api/new/v2/series/$name/recommendations?limit=10"
+        val document = app.get(url).parsed<FenrirMainPageResponse>()
+        return document.data.map { element ->
+            val href = "$mainUrl/series/${element.slug}"
+            val title = element.title
+            newSearchResponse(
+                name = title,
+                url = href
+            ) {
+                posterUrl = fixUrlNull(
+                    element.cover
+                )
+            }
+        }
+    }
 
     override suspend fun load(url: String): LoadResponse
     {
         val document = app.get(url).document
-        document.select("script, style, iframe, svg, noscript").remove()//avoid out of memory
+        document.select("style, iframe, svg, noscript").remove()//avoid out of memory
         val infoDiv = document.select("div.flex.flex-col.items-center.gap-5 div.flex-1")
         val chapters = app
             .get("$mainUrl/api/new/v2/series/${url.getSlugFromUrl()}/chapters")
@@ -113,6 +135,8 @@ class FenrirRealProvider:  MainAPI() {
             }
 
         val title = infoDiv.selectFirst("h1")?.text() ?: throw Exception("Title not found")
+        val script = document.select("script").find { it.html().contains("seriesData") }?.html() ?: ""
+        libraryId = Regex("""seriesData:\{id:(\d+)""").find(script)?.groupValues?.get(1) ?: ""
         return newStreamResponse(title,url, chapters) {
             infoDiv.select(" > div").forEachIndexed { index, inf ->
                 when (index) {
@@ -131,10 +155,31 @@ class FenrirRealProvider:  MainAPI() {
             }
             this.synopsis = document.selectFirst("div.synopsis")?.text()
             this.posterUrl = document.selectFirst("meta[property=og:image]")?.attr("content")
+            related = getRelated(url)
         }
     }
 
 
+    override suspend fun loadReviews(
+        url: String,
+        page: Int,
+        showSpoilers: Boolean
+    ): List<UserReview> {
+        if (libraryId.isEmpty()) return emptyList()
+
+        val realUrl = "$mainUrl/api/new/v2/comments/series/$libraryId?page=$page&sort=latest"
+        val res = app.get(realUrl).parsed<CommentsResponse>()
+        return res.data.map { comment ->
+            val date = comment.createdAt.split("T").firstOrNull()
+
+            UserReview(
+                review = comment.content,
+                username = comment.user.username,
+                reviewDate = date,
+                avatarUrl = fixUrlNull(comment.user.avatar)
+            )
+        }
+    }
 
     override suspend fun loadHtml(url: String): String? {
         val document = app.get(url).document
@@ -196,5 +241,25 @@ class FenrirRealProvider:  MainAPI() {
         val price: Int,
     )
 
+    data class CommentsResponse(
+        @JsonProperty("data")
+        val data: List<CommentData>
+    )
+
+    data class CommentData(
+        @JsonProperty("content")
+        val content: String,
+        @JsonProperty("created_at")
+        val createdAt: String,
+        @JsonProperty("user")
+        val user: CommentUser
+    )
+
+    data class CommentUser(
+        @JsonProperty("username")
+        val username: String,
+        @JsonProperty("avatar")
+        val avatar: String?
+    )
 }
 

--- a/app/src/main/java/com/lagradost/quicknovel/providers/FreeWebNovelProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/FreeWebNovelProvider.kt
@@ -12,7 +12,16 @@ class FreewebnovelProvider : LibReadProvider() {
     override val iconBackgroundId = R.color.wuxiaWorldOnlineColor
     override val removeHtml = true
     override val rateLimitTime = 500L
+    override val mainCategories = listOf(
+        "All" to "",
+        "Completed" to "completed"
+    )
 
+    override val orderBys = listOf(
+        "Latest Release" to "latest-release",
+        "Latest Novels" to "latest-novel",
+        "Most Popular" to "most-popular"
+    )
     override suspend fun loadMainPage(
         page: Int,
         mainCategory: String?,
@@ -20,7 +29,7 @@ class FreewebnovelProvider : LibReadProvider() {
         tag: String?
     ): HeadMainPageResponse {
         val url =
-            if (tag.isNullOrBlank()) "$mainUrl/sort/$orderBy/$page" else "$mainUrl/genres/$tag/$page"
+            if (tag.isNullOrBlank()) "$mainUrl/sort/$orderBy/${if(mainCategory.isNullOrBlank()) "" else "$mainCategory/"}$page" else "$mainUrl/genre/$tag/${if (mainCategory.isNullOrBlank()) "" else "$mainCategory/"}$page"
         val document = app.get(url).document
         val headers = document.select("div.ul-list1.ul-list1-2.ss-custom > div.li-row")
         val returnValue = headers.mapNotNull { h ->

--- a/app/src/main/java/com/lagradost/quicknovel/providers/FreeWebNovelProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/FreeWebNovelProvider.kt
@@ -1,7 +1,12 @@
 package com.lagradost.quicknovel.providers
 
-import com.lagradost.quicknovel.*
-import com.lagradost.quicknovel.MainActivity.Companion.app
+import android.net.Uri
+import com.lagradost.quicknovel.HeadMainPageResponse
+import com.lagradost.quicknovel.R
+import com.lagradost.quicknovel.SearchResponse
+import com.lagradost.quicknovel.USER_AGENT
+import com.lagradost.quicknovel.fixUrlNull
+import com.lagradost.quicknovel.newSearchResponse
 import org.jsoup.Jsoup
 
 class FreewebnovelProvider : LibReadProvider() {
@@ -11,7 +16,7 @@ class FreewebnovelProvider : LibReadProvider() {
     override val iconId = R.drawable.icon_freewebnovel
     override val iconBackgroundId = R.color.wuxiaWorldOnlineColor
     override val removeHtml = true
-    override val rateLimitTime = 500L
+    override val rateLimitTime = 800L
     override val mainCategories = listOf(
         "All" to "",
         "Completed" to "completed"
@@ -64,8 +69,32 @@ class FreewebnovelProvider : LibReadProvider() {
         document.selectFirst("div.txt>.notice-text")?.remove()
         return document.selectFirst("div.txt")?.html()
     }
-}
 
+     override suspend fun search(query: String): List<SearchResponse> {
+        val document = app.get(
+            "$mainUrl/search?keyword=${Uri.encode(query.trim()).replace("%20","+")}",
+            headers = mapOf(
+                "referer" to mainUrl,
+                "x-requested-with" to "XMLHttpRequest",
+                "content-type" to "application/x-www-form-urlencoded",
+                "accept" to "*/*",
+                "user-agent" to USER_AGENT
+            ),
+        ).document
+
+        return document.select("div.li-row > div.li > div.con").mapNotNull { h ->
+            val h3 = h.selectFirst("div.txt > h3.tit > a") ?: return@mapNotNull null
+
+            newSearchResponse(
+                name = h3.attr("title") ?: return@mapNotNull null,
+                url = h3.attr("href") ?: return@mapNotNull null
+            ) {
+                posterUrl = fixUrlNull(h.selectFirst("div.pic img")?.attr("src"))
+                //latestChapter = h.select("div.item")[2].selectFirst("> div > a")?.text()
+            }
+        }
+    }
+}
 
 /*
 class FreewebnovelProvider : MainAPI() {

--- a/app/src/main/java/com/lagradost/quicknovel/providers/HiraethTranslationProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/HiraethTranslationProvider.kt
@@ -1,8 +1,12 @@
 package com.lagradost.quicknovel.providers
 
+import android.net.Uri
 import com.lagradost.quicknovel.*
 import com.lagradost.quicknovel.MainActivity.Companion.app
+import com.lagradost.quicknovel.providers.LibReadProvider.LibReadCommentsResponse
+import com.lagradost.quicknovel.providers.NovelFireProvider.RelatedResponse
 import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
 
 open class HiraethTranslationProvider : MainAPI() {
     override val name = "HiraethTranslation"
@@ -10,7 +14,7 @@ open class HiraethTranslationProvider : MainAPI() {
     override val hasMainPage = true
     override val iconId = R.drawable.icon_hiraethtranslation
     override val iconBackgroundId = R.color.hiraethtranslation_header_color
-
+    override val hasReviews = true
     override val orderBys = listOf(
         "Latest Release" to "latest",
         "Relevance" to "",
@@ -57,7 +61,7 @@ open class HiraethTranslationProvider : MainAPI() {
     }
 
     override suspend fun search(query: String): List<SearchResponse> {
-        val document = app.get("$mainUrl/?s=$query&post_type=wp-manga&m_orderby=latest").document
+        val document = app.get("$mainUrl/?s=${Uri.encode(query.trim()).replace("%20","+")}&post_type=wp-manga").document
 
         return document.select("div.c-tabs-item > div.row.c-tabs-item__content").mapNotNull { h ->
             val h3 = h.selectFirst("h3.h4 > a") ?: return@mapNotNull null
@@ -124,6 +128,38 @@ open class HiraethTranslationProvider : MainAPI() {
             val statusHeader = document.selectFirst("div.summary-content")
 
             setStatus(statusHeader?.text() ?: statusHeader0?.text())
+            related = getRelated(document)
+        }
+    }
+
+    private fun getRelated(dc: Document): List<SearchResponse>{
+        return dc.select("div.related-manga div.col-md-3").mapNotNull { element ->
+            val href = element.selectFirst("a")?.attr("href") ?: return@mapNotNull null
+            val title = element.selectFirst("h5")?.text() ?: return@mapNotNull null
+            newSearchResponse(
+                name = title,
+                url = href
+            ) {
+                posterUrl = fixUrlNull(element.selectFirst("img")?.attr("src"))
+            }
+        }
+    }
+
+    override suspend fun loadReviews(
+        url: String,
+        page: Int,
+        showSpoilers: Boolean
+    ): List<UserReview> {
+        if (page > 1) return emptyList()
+        val response = app.get(url).document
+
+        return response.select("div.wpd-thread-list > div.comment").mapNotNull { item ->
+            UserReview(
+                review = item.selectFirst("div.wpd-comment-text")?.text() ?: "",
+                username = item.selectFirst("div.wpd-comment-author")?.text() ?: "User",
+                reviewDate = item.selectFirst("div.wpd-comment-date")?.attr("title"),
+                avatarUrl = fixUrlNull(item.selectFirst("img")?.attr("src")),
+            )
         }
     }
 }

--- a/app/src/main/java/com/lagradost/quicknovel/providers/KolNovelProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/KolNovelProvider.kt
@@ -1,7 +1,6 @@
 package com.lagradost.quicknovel.providers
 
 import com.lagradost.quicknovel.*
-import com.lagradost.quicknovel.MainActivity.Companion.app
 import java.util.*
 
 class KolNovelProvider : MainAPI() {

--- a/app/src/main/java/com/lagradost/quicknovel/providers/LibReadProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/LibReadProvider.kt
@@ -1,9 +1,19 @@
 package com.lagradost.quicknovel.providers
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.lagradost.quicknovel.*
-import com.lagradost.quicknovel.providers.NovelFireProvider.PostsResponse
-import com.lagradost.quicknovel.providers.WtrLabProvider.LoadJsonResponse2
+import com.lagradost.quicknovel.ChapterData
+import com.lagradost.quicknovel.HeadMainPageResponse
+import com.lagradost.quicknovel.LoadResponse
+import com.lagradost.quicknovel.MainAPI
+import com.lagradost.quicknovel.R
+import com.lagradost.quicknovel.SearchResponse
+import com.lagradost.quicknovel.USER_AGENT
+import com.lagradost.quicknovel.UserReview
+import com.lagradost.quicknovel.fixUrlNull
+import com.lagradost.quicknovel.newChapterData
+import com.lagradost.quicknovel.newSearchResponse
+import com.lagradost.quicknovel.newStreamResponse
+import com.lagradost.quicknovel.setStatus
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 
@@ -70,7 +80,9 @@ open class LibReadProvider : MainAPI() {
     )
 
     private suspend fun getChapterList(doc: Document, url: String): List<ChapterData> {
-        val novelId = doc.selectFirst("a.set-case.add")?.attr("data-articleid") ?: return emptyList()
+        val novelId = doc.selectFirst("a.set-case.add")?.attr("data-articleid")
+            ?: doc.selectFirst("meta[name=image]")?.attr("content")?.substringAfterLast("/")?.substringBefore("s.jpg")
+            ?: return emptyList()
         val res = app.post(
             "$mainUrl/api/chapterlist.php", data = mapOf(
                 "aid" to novelId,

--- a/app/src/main/java/com/lagradost/quicknovel/providers/LibReadProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/LibReadProvider.kt
@@ -16,6 +16,7 @@ import com.lagradost.quicknovel.newStreamResponse
 import com.lagradost.quicknovel.setStatus
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import java.util.concurrent.ConcurrentHashMap
 
 open class LibReadProvider : MainAPI() {
     override val name = "LibRead"
@@ -31,7 +32,7 @@ open class LibReadProvider : MainAPI() {
 
     override val iconBackgroundId = R.color.libread_header_color
     override val hasReviews = true
-    var novelId = ""
+    val novelsIdRequired = ConcurrentHashMap<String, String>()
 
     override val tags = listOf(
         "All" to "",
@@ -178,12 +179,11 @@ open class LibReadProvider : MainAPI() {
     }
 
     override suspend fun load(url: String): LoadResponse? {
-        novelId = ""
         val response = app.get(url)
         val document = response.document
         val name = document.selectFirst("h1.tit")?.text() ?: return null
         val chaptersDataphp = getChapterList(document, url)
-        novelId = document.selectFirst("a.set-case.add")?.attr("data-articleid") ?: ""
+        novelsIdRequired[url] = document.selectFirst("a.set-case.add")?.attr("data-articleid") ?: ""
         return newStreamResponse(url = url, name = name, data = chaptersDataphp) {
             author =
                 document.selectFirst("span.glyphicon.glyphicon-user")?.nextElementSibling()?.text()
@@ -214,7 +214,6 @@ open class LibReadProvider : MainAPI() {
         page: Int,
         showSpoilers: Boolean
     ): List<UserReview> {
-        if (novelId.isEmpty()) return emptyList()
 
         val realUrl = "$mainUrl/api/comments.php"
 
@@ -223,7 +222,7 @@ open class LibReadProvider : MainAPI() {
                 app.post(
                     realUrl, data = mapOf(
                         "action" to "list",
-                        "articleid" to novelId,
+                        "articleid" to novelsIdRequired[url].toString(),
                         "chapterid" to "0",
                         "page" to i.toString()
                     )
@@ -234,7 +233,7 @@ open class LibReadProvider : MainAPI() {
                 app.post(
                     realUrl, data = mapOf(
                         "action" to "list",
-                        "articleid" to novelId,
+                        "articleid" to novelsIdRequired[url].toString(),
                         "chapterid" to "0",
                         "page" to (page + 3).toString()
                     )

--- a/app/src/main/java/com/lagradost/quicknovel/providers/LibReadProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/LibReadProvider.kt
@@ -197,29 +197,44 @@ open class LibReadProvider : MainAPI() {
     }
 
     override suspend fun loadReviews(
-         url: String,
-         page: Int,
-         showSpoilers: Boolean
+        url: String,
+        page: Int,
+        showSpoilers: Boolean
     ): List<UserReview> {
-        if (novelId.isEmpty() || page > 1) return emptyList()
+        if (novelId.isEmpty()) return emptyList()
 
         val realUrl = "$mainUrl/api/comments.php"
 
-        val res = app.post(
-            realUrl, data = mapOf(
-                "action" to "count",
-                "articleid" to novelId,
-                "chapterid" to "0"
+        val responses: List<LibReadCommentsResponse> = if (page == 1) {
+            (1..4).mapNotNull { i ->
+                app.post(
+                    realUrl, data = mapOf(
+                        "action" to "list",
+                        "articleid" to novelId,
+                        "chapterid" to "0",
+                        "page" to i.toString()
+                    )
+                ).parsedSafe<LibReadCommentsResponse>()
+            }
+        } else {
+            listOfNotNull(
+                app.post(
+                    realUrl, data = mapOf(
+                        "action" to "list",
+                        "articleid" to novelId,
+                        "chapterid" to "0",
+                        "page" to (page + 3).toString()
+                    )
+                ).parsedSafe<LibReadCommentsResponse>()
             )
-        ).parsedSafe<LibReadCommentsResponse>()
-        val dataList = res?.data?.data_list ?: return emptyList()
+        }
 
-        return dataList.map { item ->
+        return responses.flatMap { it.data?.dataList ?: emptyList() }.map { item ->
             UserReview(
                 review = item.content ?: "",
-                username = item.user_info?.nickname ?: "User",
-                reviewDate = item.created_at,
-                avatarUrl = fixUrlNull(item.user_info?.picture),
+                username = item.userInfo?.nickname ?: "User",
+                reviewDate = item.createdAt,
+                avatarUrl = fixUrlNull(item.userInfo?.picture),
             )
         }
     }
@@ -228,14 +243,14 @@ open class LibReadProvider : MainAPI() {
     )
 
     data class LibReadCommentData(
-        @JsonProperty("is_end") val is_end: Boolean? = null,
-        @JsonProperty("data_list") val data_list: List<LibReadCommentItem>? = null
+        @JsonProperty("is_end") val isEnd: Boolean? = null,
+        @JsonProperty("data_list") val dataList: List<LibReadCommentItem>? = null
     )
 
     data class LibReadCommentItem(
         @JsonProperty("content") val content: String? = null,
-        @JsonProperty("created_at") val created_at: String? = null,
-        @JsonProperty("user_info") val user_info: LibReadUserInfo? = null
+        @JsonProperty("created_at") val createdAt: String? = null,
+        @JsonProperty("user_info") val userInfo: LibReadUserInfo? = null
     )
 
     data class LibReadUserInfo(

--- a/app/src/main/java/com/lagradost/quicknovel/providers/LibReadProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/LibReadProvider.kt
@@ -1,6 +1,9 @@
 package com.lagradost.quicknovel.providers
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.quicknovel.*
+import com.lagradost.quicknovel.providers.NovelFireProvider.PostsResponse
+import com.lagradost.quicknovel.providers.WtrLabProvider.LoadJsonResponse2
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 
@@ -17,6 +20,8 @@ open class LibReadProvider : MainAPI() {
     override val iconId = R.drawable.icon_libread
 
     override val iconBackgroundId = R.color.libread_header_color
+    override val hasReviews = true
+    var novelId = ""
 
     override val tags = listOf(
         "All" to "",
@@ -144,40 +149,28 @@ open class LibReadProvider : MainAPI() {
         }
     }
 
+    fun getRelated(dc: Document): List<SearchResponse> {
+        return dc.select("div.col-l > ul.ul-list6 > li").mapNotNull { element ->
+            val href = element.selectFirst("a")?.attr("href") ?: return@mapNotNull null
+            val title = element.selectFirst("h3")?.text() ?: return@mapNotNull null
+            newSearchResponse(
+                name = title,
+                url = href
+            ) {
+                posterUrl = fixUrlNull(
+                    element.selectFirst("img")?.attr("src")
+                )
+            }
+        }
+    }
+
     override suspend fun load(url: String): LoadResponse? {
-        //val trimmed = url.trim().removeSuffix("/")
+        novelId = ""
         val response = app.get(url)
         val document = response.document
         val name = document.selectFirst("h1.tit")?.text() ?: return null
-
-        //val aid = "[0-9]+s.jpg".toRegex().find(response.text)?.value?.substringBefore("s")
         val chaptersDataphp = getChapterList(document, url)
-        /*
-        val chaptersDataphp = app.post(
-            "$mainUrl/api/chapterlist.php",
-            data = mapOf(
-                "aid" to aid!!
-            )
-        )*/
-
-
-        /*
-        val prefix = if (removeHtml) {
-            trimmed.removeSuffix(".html")
-        } else {
-            trimmed
-        }
-
-        val data =
-            Jsoup.parse(chaptersDataphp.text.replace("""\""", "")).select("option").map { c ->
-                val cUrl = "$prefix/${c.attr("value").split('/').last()}" // url + '/' +
-                val cName = c.text().ifEmpty {
-                    "chapter $c"
-                }
-                newChapterData(url = cUrl, name = cName)
-            }
-         */
-
+        novelId = document.selectFirst("a.set-case.add")?.attr("data-articleid") ?: ""
         return newStreamResponse(url = url, name = name, data = chaptersDataphp) {
             author =
                 document.selectFirst("span.glyphicon.glyphicon-user")?.nextElementSibling()?.text()
@@ -199,11 +192,54 @@ open class LibReadProvider : MainAPI() {
             setStatus(
                 statusHeader?.selectFirst("a")?.text() ?: statusHeader0?.selectFirst("a")?.text()
             )
+            related = getRelated(document)
         }
     }
 
-    data class ChapterResponse(
-        val code:Int,
-        val html: String
+    override suspend fun loadReviews(
+         url: String,
+         page: Int,
+         showSpoilers: Boolean
+    ): List<UserReview> {
+        if (novelId.isEmpty() || page > 1) return emptyList()
+
+        val realUrl = "$mainUrl/api/comments.php"
+
+        val res = app.post(
+            realUrl, data = mapOf(
+                "action" to "count",
+                "articleid" to novelId,
+                "chapterid" to "0"
+            )
+        ).parsedSafe<LibReadCommentsResponse>()
+        val dataList = res?.data?.data_list ?: return emptyList()
+
+        return dataList.map { item ->
+            UserReview(
+                review = item.content ?: "",
+                username = item.user_info?.nickname ?: "User",
+                reviewDate = item.created_at,
+                avatarUrl = fixUrlNull(item.user_info?.picture),
+            )
+        }
+    }
+    data class LibReadCommentsResponse(
+        @JsonProperty("data") val data: LibReadCommentData? = null
+    )
+
+    data class LibReadCommentData(
+        @JsonProperty("is_end") val is_end: Boolean? = null,
+        @JsonProperty("data_list") val data_list: List<LibReadCommentItem>? = null
+    )
+
+    data class LibReadCommentItem(
+        @JsonProperty("content") val content: String? = null,
+        @JsonProperty("created_at") val created_at: String? = null,
+        @JsonProperty("user_info") val user_info: LibReadUserInfo? = null
+    )
+
+    data class LibReadUserInfo(
+        @JsonProperty("nickname") val nickname: String? = null,
+        @JsonProperty("picture") val picture: String? = null
     )
 }

--- a/app/src/main/java/com/lagradost/quicknovel/providers/LibReadProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/LibReadProvider.kt
@@ -69,19 +69,20 @@ open class LibReadProvider : MainAPI() {
         "Completed Novels" to "completed-novel"
     )
 
-    private fun getChapterList(doc: Document, url: String): List<ChapterData> {
-        val scriptData = doc.select("script").map { it.data() }
-            .find { it.contains("window.chapterPagination") } ?: return emptyList()
-
-        val totalChapters = "totalChapters:\\s*(\\d+)".toRegex()
-            .find(scriptData)?.groupValues?.get(1)?.toIntOrNull() ?: 0
-
-        val cleanedUrl = url.removeSuffix("/").substringAfterLast("/").replace("(-novel)?-\\d{4,}+$".toRegex(), "")
-
-        return (1..totalChapters).map { i ->
+    private suspend fun getChapterList(doc: Document, url: String): List<ChapterData> {
+        val novelId = doc.selectFirst("a.set-case.add")?.attr("data-articleid") ?: return emptyList()
+        val res = app.post(
+            "$mainUrl/api/chapterlist.php", data = mapOf(
+                "aid" to novelId,
+                "acode" to url.removeSuffix("/").substringAfterLast("/"),
+                "cid" to "1"
+            )
+        ).parsed<ChaptersResponse>()
+        val document = Jsoup.parse(res.html)
+        return document.select("option").mapNotNull { i ->
             newChapterData(
-                name = "Chapter $i",
-                url = "$secondUrl/novel/$cleanedUrl/chapter-$i"
+                name = i.text(),
+                url = "$secondUrl${i.attr("value")}"
             )
         }
     }
@@ -256,5 +257,9 @@ open class LibReadProvider : MainAPI() {
     data class LibReadUserInfo(
         @JsonProperty("nickname") val nickname: String? = null,
         @JsonProperty("picture") val picture: String? = null
+    )
+
+    data class ChaptersResponse(
+        @JsonProperty("html") val html: String
     )
 }

--- a/app/src/main/java/com/lagradost/quicknovel/providers/LightNovelWorldProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/LightNovelWorldProvider.kt
@@ -28,11 +28,75 @@ class LightNovelWorldProvider : MainAPI() {
     override val hasReviews = true
     var novelId = ""
     override val mainCategories = listOf(
-        "New Update" to "/updates/",
-        "Top Ranked" to "/ranking/?sort=rank",
-        "Top Reviews" to "/ranking/?sort=reviews",
-        "Top Comments" to "/ranking/?sort=comments",
-        "Top Collections" to "/ranking/?sort=collections"
+        "All" to "all",
+        "Ongoing" to "ongoing",
+        "Completed" to "completed"
+    )
+
+    override val tags = listOf(
+        "All" to "all",
+        "Action" to "action",
+        "Adult" to "adult",
+        "Adventure" to "adventure",
+        "Anime" to "anime",
+        "Arts" to "arts",
+        "Comedy" to "comedy",
+        "Drama" to "drama",
+        "Eastern" to "eastern",
+        "Ecchi" to "ecchi",
+        "Fan-Fiction" to "fan-fiction",
+        "Fantasy" to "fantasy",
+        "Game" to "game",
+        "Gender-Bender" to "gender-bender",
+        "Harem" to "harem",
+        "Historical" to "historical",
+        "Horror" to "horror",
+        "Isekai" to "isekai",
+        "Josei" to "josei",
+        "Lgbt+" to "lgbt+",
+        "Magic" to "magic",
+        "Magical-Realism" to "magical-realism",
+        "Manhua" to "manhua",
+        "Martial-Arts" to "martial-arts",
+        "Mature" to "mature",
+        "Mecha" to "mecha",
+        "Military" to "military",
+        "Modern-Life" to "modern-life",
+        "Movies" to "movies",
+        "Mystery" to "mystery",
+        "Other" to "other",
+        "Psychological" to "psychological",
+        "Realistic-Fiction" to "realistic-fiction",
+        "Reincarnation" to "reincarnation",
+        "Romance" to "romance",
+        "School-Life" to "school-life",
+        "Sci-Fi" to "sci-fi",
+        "Seinen" to "seinen",
+        "Shoujo" to "shoujo",
+        "Shoujo-Ai" to "shoujo-ai",
+        "Shounen" to "shounen",
+        "Shounen-Ai" to "shounen-ai",
+        "Slice-Of-Life" to "slice-of-life",
+        "Smut" to "smut",
+        "Sports" to "sports",
+        "Supernatural" to "supernatural",
+        "System" to "system",
+        "Tragedy" to "tragedy",
+        "Urban" to "urban",
+        "Urban-Life" to "urban-life",
+        "Video-Games" to "video-games",
+        "War" to "war",
+        "Wuxia" to "wuxia",
+        "Xianxia" to "xianxia",
+        "Xuanhuan" to "xuanhuan",
+        "Yaoi" to "yaoi",
+        "Yuri" to "yuri"
+    )
+
+    override val orderBys = listOf(
+        "New" to "new",
+        "Popular" to "popular",
+        "Updates" to "updates"
     )
 
     data class SearchNovel(
@@ -51,22 +115,16 @@ class LightNovelWorldProvider : MainAPI() {
         orderBy: String?,
         tag: String?
     ): HeadMainPageResponse {
-        val url = withPageParam(fixUrl(mainCategory ?: "/updates/"), page)
+        val url = "$mainUrl/genre-$tag/?page=$page&order=$orderBy&status$mainCategory"
         val document = app.get(url).document
 
-        val cards = (document.select("div.ranking-list > a") + document.select("a.card-link"))
-            .distinctBy { it.attr("href") }
-
-        val novels = cards.mapNotNull { card ->
-            val href = card.attr("href").takeIf { it.isNotBlank() } ?: return@mapNotNull null
-            val title = card.selectFirst("h4.ranking-item-title, h3.card-title, h4")?.text()?.trim()
-                ?: return@mapNotNull null
+        val novels = document.select("div.recommendations-grid > div.recommendation-card").mapNotNull { card ->
+            val href = card.selectFirst("a")?.attr("href") ?: return@mapNotNull null
+            val title = card.selectFirst("h3")?.text() ?: return@mapNotNull null
 
             newSearchResponse(name = title, url = href) {
                 posterUrl = fixUrlNull(
-                    card.selectFirst("div.ranking-item-cover > img")?.attr("src")
-                        ?: card.selectFirst("div.card-cover")?.attr("data-bg-image")
-                        ?: card.selectFirst("img")?.attr("src")
+                    card.selectFirst("img")?.attr("src")
                 )
             }
         }
@@ -104,7 +162,9 @@ class LightNovelWorldProvider : MainAPI() {
                     ?: document.selectFirst("img.novel-cover")?.attr("src")
             )
             synopsis = document.selectFirst("div.summary-content")?.text()?.trim()
-            tags = document.select("div.genre-tags > span.genre-tag").map { it.text().trim() }
+            tags = document.select("div.genre-tags > span.genre-tag").map {
+                it.text().trim().lowercase().replaceFirstChar { char -> char.uppercase() }
+            }
             setStatus(document.selectFirst("span.status-badge")?.text()?.trim())
             related = getRelated()
         }
@@ -202,11 +262,6 @@ class LightNovelWorldProvider : MainAPI() {
             }
         }
     }
-
-    private fun withPageParam(url: String, page: Int): String {
-        return if (url.contains("?")) "$url&page=$page" else "$url?page=$page"
-    }
-
     data class RelatedResponse(
         @JsonProperty("novels")
         val novels:List<Novel>

--- a/app/src/main/java/com/lagradost/quicknovel/providers/LightNovelWorldProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/LightNovelWorldProvider.kt
@@ -8,12 +8,16 @@ import com.lagradost.quicknovel.LoadResponse
 import com.lagradost.quicknovel.MainAPI
 import com.lagradost.quicknovel.R
 import com.lagradost.quicknovel.SearchResponse
+import com.lagradost.quicknovel.UserReview
 import com.lagradost.quicknovel.fixUrl
 import com.lagradost.quicknovel.fixUrlNull
 import com.lagradost.quicknovel.newChapterData
 import com.lagradost.quicknovel.newSearchResponse
 import com.lagradost.quicknovel.newStreamResponse
+import com.lagradost.quicknovel.providers.NovelFireProvider.PostsResponse
+import com.lagradost.quicknovel.providers.NovelFireProvider.RelatedResponse
 import com.lagradost.quicknovel.setStatus
+import org.jsoup.Jsoup
 
 class LightNovelWorldProvider : MainAPI() {
     override val name = "LightNovelWorld"
@@ -21,7 +25,8 @@ class LightNovelWorldProvider : MainAPI() {
     override val hasMainPage = true
     override val iconId = R.drawable.icon_lightnovelworld
     override val iconBackgroundId = R.color.colorPrimaryWhite
-
+    override val hasReviews = true
+    var novelId = ""
     override val mainCategories = listOf(
         "New Update" to "/updates/",
         "Top Ranked" to "/ranking/?sort=rank",
@@ -85,7 +90,7 @@ class LightNovelWorldProvider : MainAPI() {
 
     override suspend fun load(url: String): LoadResponse? {
         val document = app.get(url).document
-
+        novelId = document.selectFirst("meta[name=novel-id]")?.attr("content") ?: ""
         val title = document.selectFirst("h1.novel-title, meta[property=og:title]")?.let {
             if (it.tagName() == "meta") it.attr("content") else it.text()
         }?.trim() ?: return null
@@ -101,6 +106,50 @@ class LightNovelWorldProvider : MainAPI() {
             synopsis = document.selectFirst("div.summary-content")?.text()?.trim()
             tags = document.select("div.genre-tags > span.genre-tag").map { it.text().trim() }
             setStatus(document.selectFirst("span.status-badge")?.text()?.trim())
+            related = getRelated()
+        }
+    }
+    suspend fun getRelated(): List<SearchResponse> {
+        val url = "$mainUrl/api/recommendations/"
+        val document = app.get(url).parsed<RelatedResponse>()
+        return document.novels.map { element ->
+            val href = fixUrl(element.slug)
+            val title = element.title
+            newSearchResponse(
+                name = title,
+                url = href
+            ) {
+                posterUrl = fixUrlNull(element.coverPath)
+            }
+        }
+    }
+
+    override suspend fun loadReviews(
+        url: String,
+        page: Int,
+        showSpoilers: Boolean
+    ): List<UserReview> {
+        if (novelId.isEmpty()) return emptyList()
+        val realUrl = "$mainUrl/api/comments/?comment_type=novel&commentable_id=$novelId&sort=newest&page=$page&parent_only=true"
+        val res = app.get(realUrl).parsedSafe<PostsResponse>()
+        val dataList = res?.comments ?: return emptyList()
+
+        return dataList.map { item ->
+            val content = if (item.isSpoiler == true && !showSpoilers) {
+                "Spoiler content hidden"
+            } else {
+                item.content ?: ""
+            }
+
+            // ¿2025-10-18T23:39:33..." -> "2025-10-18 23:39:33"
+            val cleanDate = item.createdAt?.replace("T", " ")
+
+            UserReview(
+                review = content,
+                username = item.author?.username ?: "User",
+                reviewDate = cleanDate,
+                avatarUrl = fixUrlNull(item.author?.profileImageUrl),
+            )
         }
     }
 
@@ -157,4 +206,39 @@ class LightNovelWorldProvider : MainAPI() {
     private fun withPageParam(url: String, page: Int): String {
         return if (url.contains("?")) "$url&page=$page" else "$url?page=$page"
     }
+
+    data class RelatedResponse(
+        @JsonProperty("novels")
+        val novels:List<Novel>
+    )
+    data class Novel(
+        @JsonProperty("title")
+        val title:String,
+        @JsonProperty("slug")
+        val slug:String,
+        @JsonProperty("cover_path")
+        val coverPath:String
+    )
+    data class PostsResponse(
+        @JsonProperty("comments") val comments: List<Comment>? = null,        @JsonProperty("pagination") val pagination: Pagination? = null
+    )
+
+    data class Pagination(
+        @JsonProperty("current_page") val currentPage: Int? = null,
+        @JsonProperty("total_pages") val totalPages: Int? = null,
+        @JsonProperty("has_next") val hasNext: Boolean? = null
+    )
+
+    data class Comment(
+        @JsonProperty("content") val content: String? = null,
+        @JsonProperty("created_at") val createdAt: String? = null,
+        @JsonProperty("author") val author: Author? = null,
+        @JsonProperty("is_spoiler") val isSpoiler: Boolean? = null
+    )
+
+    data class Author(
+        @JsonProperty("username") val username: String? = null,
+        @JsonProperty("profile_image_url") val profileImageUrl: String? = null
+    )
+
 }

--- a/app/src/main/java/com/lagradost/quicknovel/providers/LightNovelWorldProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/LightNovelWorldProvider.kt
@@ -18,6 +18,7 @@ import com.lagradost.quicknovel.providers.NovelFireProvider.PostsResponse
 import com.lagradost.quicknovel.providers.NovelFireProvider.RelatedResponse
 import com.lagradost.quicknovel.setStatus
 import org.jsoup.Jsoup
+import java.util.concurrent.ConcurrentHashMap
 
 class LightNovelWorldProvider : MainAPI() {
     override val name = "LightNovelWorld"
@@ -26,7 +27,7 @@ class LightNovelWorldProvider : MainAPI() {
     override val iconId = R.drawable.icon_lightnovelworld
     override val iconBackgroundId = R.color.colorPrimaryWhite
     override val hasReviews = true
-    var novelId = ""
+    val novelsIdRequired = ConcurrentHashMap<String, String>()
     override val mainCategories = listOf(
         "All" to "all",
         "Ongoing" to "ongoing",
@@ -148,7 +149,7 @@ class LightNovelWorldProvider : MainAPI() {
 
     override suspend fun load(url: String): LoadResponse? {
         val document = app.get(url).document
-        novelId = document.selectFirst("meta[name=novel-id]")?.attr("content") ?: ""
+        novelsIdRequired[url] = document.selectFirst("meta[name=novel-id]")?.attr("content") ?: ""
         val title = document.selectFirst("h1.novel-title, meta[property=og:title]")?.let {
             if (it.tagName() == "meta") it.attr("content") else it.text()
         }?.trim() ?: return null
@@ -189,8 +190,7 @@ class LightNovelWorldProvider : MainAPI() {
         page: Int,
         showSpoilers: Boolean
     ): List<UserReview> {
-        if (novelId.isEmpty()) return emptyList()
-        val realUrl = "$mainUrl/api/comments/?comment_type=novel&commentable_id=$novelId&sort=newest&page=$page&parent_only=true"
+        val realUrl = "$mainUrl/api/comments/?comment_type=novel&commentable_id=${novelsIdRequired[url]}&sort=newest&page=$page&parent_only=true"
         val res = app.get(realUrl).parsedSafe<PostsResponse>()
         val dataList = res?.comments ?: return emptyList()
 

--- a/app/src/main/java/com/lagradost/quicknovel/providers/MtlNovelsProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/MtlNovelsProvider.kt
@@ -5,10 +5,12 @@ import com.lagradost.quicknovel.LoadResponse
 import com.lagradost.quicknovel.MainAPI
 import com.lagradost.quicknovel.R
 import com.lagradost.quicknovel.SearchResponse
+import com.lagradost.quicknovel.fixUrl
 import com.lagradost.quicknovel.fixUrlNull
 import com.lagradost.quicknovel.newChapterData
 import com.lagradost.quicknovel.newSearchResponse
 import com.lagradost.quicknovel.newStreamResponse
+import com.lagradost.quicknovel.providers.LightNovelWorldProvider.RelatedResponse
 
 class MtlNovelProvider : MainAPI() {
     override val name = "MtlNovel"
@@ -140,7 +142,22 @@ class MtlNovelProvider : MainAPI() {
                 ?.toFloat()
                 ?.times(200)
                 ?.toInt()
+            related = getRelated(url.substringAfter("info/").removeSuffix("/"))
         }
+    }
 
+    suspend fun getRelated(slug:String): List<SearchResponse> {
+        val url = "$mainUrl/ajax/list/?type=related&slug=$slug"
+        val document = app.get(url).document
+        return document.select("div.novel-box").mapNotNull { element ->
+            val href = element.selectFirst("a")?.attr("href") ?: return@mapNotNull null
+            val title = element.selectFirst("h3")?.text() ?: return@mapNotNull null
+            newSearchResponse(
+                name = title,
+                url = href
+            ) {
+                posterUrl = fixUrlNull(element.selectFirst("img")?.attr("src"))
+            }
+        }
     }
 }

--- a/app/src/main/java/com/lagradost/quicknovel/providers/MtlNovelsProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/MtlNovelsProvider.kt
@@ -131,7 +131,7 @@ class MtlNovelProvider : MainAPI() {
 
             posterUrl = fixUrlNull(document.selectFirst("div.content-main-image img")?.attr("src"))
 
-            tags = lis.getOrNull(5)?.select("a")?.map { it.text() }
+            tags = lis.getOrNull(3)?.select("a")?.map { it.text() }
 
             synopsis = document.selectFirst("div.m-card.text-break")?.ownText()
 

--- a/app/src/main/java/com/lagradost/quicknovel/providers/NovelBinProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/NovelBinProvider.kt
@@ -1,104 +1,232 @@
 package com.lagradost.quicknovel.providers
 
+import android.net.Uri
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.lagradost.quicknovel.ChapterData
+import com.lagradost.quicknovel.ErrorLoadingException
 import com.lagradost.quicknovel.HeadMainPageResponse
+import com.lagradost.quicknovel.LoadResponse
+import com.lagradost.quicknovel.MainAPI
 import com.lagradost.quicknovel.R
-import com.lagradost.quicknovel.fixUrlNull
+import com.lagradost.quicknovel.SearchResponse
+import com.lagradost.quicknovel.newChapterData
 import com.lagradost.quicknovel.newSearchResponse
+import com.lagradost.quicknovel.newStreamResponse
+import com.lagradost.quicknovel.setStatus
 
 
-open class NovelBinProvider : AllNovelProvider() {
+open class NovelBinProvider : MainAPI() {
     override val name = "NovelBin"
-    override val mainUrl = "https://novelbin.com"
-    override val ajaxUrl = "ajax/chapter-archive"
+    override val mainUrl = "https://novelarrow.com"
     override val hasMainPage = true
-
     override val usesCloudFlareKiller = true
-
     override val iconId = R.drawable.icon_novelbin
+
+    override val mainCategories =listOf(
+        "All" to "all"
+    )
     override val tags = listOf(
-        "All" to "All",
-        "Action" to "action",
-        "Adventure" to "adventure",
-        "Anime & comics" to "anime-&-comics",
-        "Comedy" to "comedy",
-        "Drama" to "drama",
-        "Eastern" to "eastern",
-        "Fanfiction" to "fanfiction",
-        "Fantasy" to "fantasy",
-        "Game" to "game",
-        "Gender bender" to "gender-bender",
-        "Harem" to "harem",
-        "Historical" to "historical",
-        "Horror" to "horror",
-        "Isekai" to "isekai",
-        "Josei" to "josei",
-        "Litrpg" to "litrpg",
-        "Magic" to "magic",
-        "Magical realism" to "magical-realism",
-        "Martial arts" to "martial-arts",
-        "Mature" to "mature",
-        "Mecha" to "mecha",
-        "Modern life" to "modern-life",
-        "Mystery" to "mystery",
-        "Other" to "other",
-        "Psychological" to "psychological",
-        "Reincarnation" to "reincarnation",
-        "Romance" to "romance",
-        "School life" to "school-life",
-        "Sci-fi" to "sci-fi",
-        "Seinen" to "seinen",
-        "Shoujo" to "shoujo",
-        "Shoujo ai" to "shoujo-ai",
-        "Shounen" to "shounen",
-        "Shounen ai" to "shounen-ai",
-        "Slice of life" to "slice-of-life",
-        "Smut" to "smut",
-        "Sports" to "sports",
-        "Supernatural" to "supernatural",
-        "System" to "system",
-        "Tragedy" to "tragedy",
-        "Urban life" to "urban-life",
-        "Video games" to "video-games",
-        "Wuxia" to "wuxia",
-        "Xianxia" to "xianxia",
-        "Xuanhuan" to "xuanhuan",
-        "Yaoi" to "yaoi",
-        "Yuri" to "yuri",
+        "All Genres" to "ALL",
+        "Action" to "ACTION",
+        "Adult" to "ADULT",
+        "Adventure" to "ADVENTURE",
+        "Adventurei" to "ADVENTUREI",
+        "Anime & Comics" to "ANIME & COMICS",
+        "Comedy" to "COMEDY",
+        "Drama" to "DRAMA",
+        "Eastern" to "EASTERN",
+        "Ecchi" to "ECCHI",
+        "Fan-fiction" to "FAN-FICTION",
+        "Fantasy" to "FANTASY",
+        "Game" to "GAME",
+        "Gender Bender" to "GENDER BENDER",
+        "Harem" to "HAREM",
+        "Historical" to "HISTORICAL",
+        "Horror" to "HORROR",
+        "Isekai" to "ISEKAI",
+        "Josei" to "JOSEI",
+        "LGBT+" to "LGBT+",
+        "LitRPG" to "LITRPG",
+        "Magic" to "MAGIC",
+        "Magical Realism" to "MAGICAL REALISM",
+        "Martial Arts" to "MARTIAL ARTS",
+        "Mature" to "MATURE",
+        "Mecha" to "MECHA",
+        "Military" to "MILITARY",
+        "Modern Life" to "MODERN LIFE",
+        "Mystery" to "MYSTERY",
+        "Other" to "OTHER",
+        "Psychological" to "PSYCHOLOGICAL",
+        "Realistic" to "REALISTIC",
+        "Reincarnation" to "REINCARNATION",
+        "Romance" to "ROMANCE",
+        "Romancel" to "ROMANCEL",
+        "School Life" to "SCHOOL LIFE",
+        "Sci-Fi" to "SCI-FI",
+        "Seinen" to "SEINEN",
+        "Shoujo" to "SHOUJO",
+        "Shoujo Ai" to "SHOUJO AI",
+        "Shounen" to "SHOUNEN",
+        "Shounen Ai" to "SHOUNEN AI",
+        "Slice of Life" to "SLICE OF LIFE",
+        "Smut" to "SMUT",
+        "Sports" to "SPORTS",
+        "Supernatural" to "SUPERNATURAL",
+        "System" to "SYSTEM",
+        "Thriller" to "THRILLER",
+        "Tragedy" to "TRAGEDY",
+        "Urban" to "URBAN",
+        "Video Games" to "VIDEO GAMES",
+        "War" to "WAR",
+        "Wuxia" to "WUXIA",
+        "Xianxia" to "XIANXIA",
+        "Xuanhuan" to "XUANHUAN",
+        "Yaoi" to "YAOI",
+        "Yuri" to "YURI",
     )
 
     override val orderBys = listOf(
-        "Genre" to "",
-        "Latest Release" to "sort/latest",
-        "Hot Novel" to "sort/top-hot-novel",
-        "Completed Novel" to "sort/completed",
-        "Most Popular" to "sort/top-view-novel",
-        "Store" to "store",
+        "Last" to "LASTEST",
     )
 
-    override fun String.fullPosterFix(): String =
-        this.replace(Regex("/novel_[0-9]*_[0-9]*/"), "/novel/")
 
     override suspend fun loadMainPage(
         page: Int,
         mainCategory: String?,
         orderBy: String?,
         tag: String?
-    ): HeadMainPageResponse {
-        val url =
-            if (orderBy == "" && tag != "All") "$mainUrl/genre/$tag?page=$page" else "$mainUrl/${if (orderBy.isNullOrBlank()) "sort/top-hot-novel" else orderBy}?page=$page"
-        val document = app.get(url).document
+    ): HeadMainPageResponse
+    {
+        val url = "$mainUrl/api-web/novels?limit=30&page=$page&status=$mainCategory&sort=$orderBy&genre=$tag"
+        val document = app.get(url).parsed<MainPageResponse>()
 
-        return HeadMainPageResponse(
-            url,
-            list = document.select("div.list>div.row").mapNotNull { element ->
-                val a =
-                    element.selectFirst("div > div > h3.novel-title > a") ?: return@mapNotNull null
-                newSearchResponse(
-                    name = a.text(),
-                    url = fixUrlNull(a.attr("href")) ?: return@mapNotNull null,
-                ){
-                    posterUrl = fixUrlNull(element.selectFirst("div > div > img")?.attr("data-src")?.fullPosterFix())
-                }
-            })
+        val returnValue = document.items.map { card ->
+            val href = "$mainUrl/novel/" + card.novelId
+            val title = card.novelName
+            newSearchResponse(
+                name = title,
+                url = href
+            ) {
+                posterUrl = "https://images.novelarrow.com/novel_164_245/" + card.novelId + ".jpg"
+            }
+        }
+        return HeadMainPageResponse(url, returnValue)
     }
+
+    suspend fun getChapters(slug: String): List<ChapterData> {
+        val response = app.get("$mainUrl/api-web/novels/$slug/chapters?sort=asc")
+
+        val chapters = try {
+            response.parsed<ChaptersResponse>().items
+        } catch (_: Exception) {
+            response.parsed<ChaptersResponseNested>().items.flatten()
+        }
+
+        return chapters.mapNotNull { ch ->
+            if (ch.premium || ch.platinum) return@mapNotNull null
+
+            newChapterData(
+                name = ch.chapterName,
+                url = "$mainUrl/chapter/$slug/${ch.chapterId}"
+            )
+        }
+    }
+
+
+    override suspend fun load(url: String): LoadResponse
+    {
+        val realUrl = url.replace("https://novelbin.com/b/", mainUrl + "/novel/")
+        val document = app.get(realUrl).document
+        val title = document.selectFirst("title")?.text() ?: throw ErrorLoadingException("No title")
+
+        val chapters = getChapters(realUrl.substringAfter("/novel/"))
+        return newStreamResponse(title,realUrl,chapters) {
+            this.posterUrl = document.selectFirst("meta[property=og:image]")?.attr("content")
+            this.synopsis = document.selectFirst("meta[name=description]")?.attr("content")
+            this.author = document.selectFirst("meta[name=author]")?.attr("content")
+            this.tags = document.selectFirst("meta[name=category]")?.attr("content")?.let {listOf(it)}
+            setStatus(document.selectFirst("meta[name=og:novel:status]")?.attr("content"))
+        }
+    }
+
+    override suspend fun loadHtml(url: String): String {
+        val document = app.get(url).document
+        val script = document.select("script")
+            .firstOrNull {
+                it.data().contains("\\u003ch1\\u003e")
+            }?.data()
+            ?: error("No encontrado")
+
+        val raw = Regex(
+            """"((?:\\.|[^"])*)"""",
+            RegexOption.DOT_MATCHES_ALL
+        ).findAll(script)
+            .map { it.groupValues[1] }
+            .first { it.contains("\\u003ch1\\u003e") }
+
+        //I'm not sure if this is the right way to do it, or if there's already a function that does this.
+        return ObjectMapper().readValue("\"$raw\"", String::class.java)
+    }
+
+    override suspend fun search(query: String): List<SearchResponse> {
+        val url = "$mainUrl/api-web/novels?limit=5&page=1&status=all&sort=SEARCH_KEYWORD&genre=ALL&keyword=${Uri.encode(query.trim()).replace("%20","+")}"
+        val document = app.get(url).parsed<MainPageResponse>()
+
+        return document.items.map { card ->
+            val href = "$mainUrl/novel/" + card.novelId
+            val title = card.novelName
+            newSearchResponse(
+                name = title,
+                url = href
+            ) {
+                posterUrl = "https://images.novelarrow.com/novel_164_245/" + card.novelId + ".jpg"
+            }
+        }
+    }
+
+    data class MainPageResponse(
+        @JsonProperty("items") val items:List<NovelInfo>
+    )
+    data class NovelInfo(
+        @JsonProperty("novel_name") val novelName:String,
+        @JsonProperty("novel_id") val novelId:String
+    )
+
+    data class ChaptersResponse(
+        val items: List<ChapterInfo>,
+        val pagination: Pagination
+    )
+
+    data class ChaptersResponseNested(
+        val items: List<List<ChapterInfo>>,
+        val pagination: Pagination
+    )
+
+    data class ChapterInfo(
+        @JsonProperty("chapter_id")
+        val chapterId: String,
+
+        @JsonProperty("chapter_name")
+        val chapterName: String,
+
+        @JsonProperty("platinum_content")
+        val platinum: Boolean,
+
+        @JsonProperty("premium_content")
+        val premium: Boolean,
+
+        @JsonProperty("coin_price")
+        val coinPrice: Int,
+
+        @JsonProperty("comments_count")
+        val commentsCount: Int
+    )
+
+    data class Pagination(
+        val page: Int,
+        val limit: Int,
+        val total: Int,
+        val totalPages: Int
+    )
 }

--- a/app/src/main/java/com/lagradost/quicknovel/providers/NovelBinProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/NovelBinProvider.kt
@@ -10,10 +10,13 @@ import com.lagradost.quicknovel.LoadResponse
 import com.lagradost.quicknovel.MainAPI
 import com.lagradost.quicknovel.R
 import com.lagradost.quicknovel.SearchResponse
+import com.lagradost.quicknovel.UserReview
+import com.lagradost.quicknovel.fixUrlNull
 import com.lagradost.quicknovel.newChapterData
 import com.lagradost.quicknovel.newSearchResponse
 import com.lagradost.quicknovel.newStreamResponse
 import com.lagradost.quicknovel.setStatus
+import org.jsoup.nodes.Document
 
 
 open class NovelBinProvider : MainAPI() {
@@ -22,6 +25,7 @@ open class NovelBinProvider : MainAPI() {
     override val hasMainPage = true
     override val usesCloudFlareKiller = true
     override val iconId = R.drawable.icon_novelbin
+    override val hasReviews = true
 
     override val mainCategories =listOf(
         "All" to "all"
@@ -134,20 +138,56 @@ open class NovelBinProvider : MainAPI() {
     }
 
 
-    override suspend fun load(url: String): LoadResponse
-    {
+    override suspend fun load(url: String): LoadResponse {
         val realUrl = url.replace("https://novelbin.com/b/", mainUrl + "/novel/")
         val document = app.get(realUrl).document
         val title = document.selectFirst("title")?.text() ?: throw ErrorLoadingException("No title")
 
         val chapters = getChapters(realUrl.substringAfter("/novel/"))
-        return newStreamResponse(title,realUrl,chapters) {
+        return newStreamResponse(title, realUrl, chapters) {
             this.posterUrl = document.selectFirst("meta[property=og:image]")?.attr("content")
             this.synopsis = document.selectFirst("meta[name=description]")?.attr("content")
             this.author = document.selectFirst("meta[name=author]")?.attr("content")
-            this.tags = document.selectFirst("meta[name=category]")?.attr("content")?.let {listOf(it)}
+            this.tags =
+                document.selectFirst("meta[name=category]")?.attr("content")?.let { listOf(it) }
             setStatus(document.selectFirst("meta[name=og:novel:status]")?.attr("content"))
+            related = getRelated(document)
         }
+    }
+
+    private fun getRelated(dc: Document): List<SearchResponse>{
+        return dc.select("aside.classic-detail-aside > section.mt-5 > div.site-panel > div > a.group").mapNotNull { element ->
+            val href = element.attr("href") ?: return@mapNotNull null
+            val title = element.selectFirst("> div.font-extrabold")?.text() ?: return@mapNotNull null
+            newSearchResponse(
+                name = title,
+                url = href
+            ) {
+                posterUrl = fixUrlNull(element.selectFirst("img")?.attr("src"))
+            }
+        }
+    }
+
+    override suspend fun loadReviews(
+        url: String,
+        page: Int,
+        showSpoilers: Boolean
+    ): List<UserReview> {
+        val slug = url.removeSuffix("/").substringAfter("/novel/")
+        val realUrl = "$mainUrl/api-web/novels/$slug/comments?page=$page&limit=10&sort=most-liked&scope=novel"
+
+        val response = app.get(realUrl).parsedSafe<ReviewResponse>()
+
+        return response?.items?.mapNotNull { item ->
+            if (!showSpoilers && item.isSpoiler == true) return@mapNotNull null
+
+            UserReview(
+                review = org.jsoup.Jsoup.parse(item.content ?: "").text(),
+                username = item.disqusUser?.name ?: "User",
+                reviewDate = item.createdDate,
+                avatarUrl = fixUrlNull(item.disqusUser?.avatarUrl),
+            )
+        } ?: emptyList()
     }
 
     override suspend fun loadHtml(url: String): String {
@@ -228,5 +268,20 @@ open class NovelBinProvider : MainAPI() {
         val limit: Int,
         val total: Int,
         val totalPages: Int
+    )
+
+    data class ReviewResponse(@JsonProperty("items") val items: List<ReviewItem>?
+    )
+
+    data class ReviewItem(
+        @JsonProperty("content") val content: String?,
+        @JsonProperty("isSpoiler") val isSpoiler: Boolean?,
+        @JsonProperty("disqusUser") val disqusUser: DisqusUser?,
+        @JsonProperty("created_date") val createdDate: String?
+    )
+
+    data class DisqusUser(
+        @JsonProperty("name") val name: String?,
+        @JsonProperty("avatarUrl") val avatarUrl: String?
     )
 }

--- a/app/src/main/java/com/lagradost/quicknovel/providers/NovelBinProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/NovelBinProvider.kt
@@ -27,71 +27,71 @@ open class NovelBinProvider : MainAPI() {
     override val iconId = R.drawable.icon_novelbin
     override val hasReviews = true
 
-    override val mainCategories =listOf(
-        "All" to "all"
+    override val mainCategories = listOf(
+        "Popular this week" to "POPULAR",
+        "Last updated" to "",
+        "Recently added" to "NEW",
+        "Top (most viewed)" to "ALL_TIME",
+        "Top rated" to "RATING",
+        "Most chapters" to "CHAPTERS"
     )
     override val tags = listOf(
-        "All Genres" to "ALL",
-        "Action" to "ACTION",
-        "Adult" to "ADULT",
-        "Adventure" to "ADVENTURE",
-        "Adventurei" to "ADVENTUREI",
-        "Anime & Comics" to "ANIME & COMICS",
-        "Comedy" to "COMEDY",
-        "Drama" to "DRAMA",
-        "Eastern" to "EASTERN",
-        "Ecchi" to "ECCHI",
-        "Fan-fiction" to "FAN-FICTION",
-        "Fantasy" to "FANTASY",
-        "Game" to "GAME",
-        "Gender Bender" to "GENDER BENDER",
-        "Harem" to "HAREM",
-        "Historical" to "HISTORICAL",
-        "Horror" to "HORROR",
-        "Isekai" to "ISEKAI",
-        "Josei" to "JOSEI",
-        "LGBT+" to "LGBT+",
-        "LitRPG" to "LITRPG",
-        "Magic" to "MAGIC",
-        "Magical Realism" to "MAGICAL REALISM",
-        "Martial Arts" to "MARTIAL ARTS",
-        "Mature" to "MATURE",
-        "Mecha" to "MECHA",
-        "Military" to "MILITARY",
-        "Modern Life" to "MODERN LIFE",
-        "Mystery" to "MYSTERY",
-        "Other" to "OTHER",
-        "Psychological" to "PSYCHOLOGICAL",
-        "Realistic" to "REALISTIC",
-        "Reincarnation" to "REINCARNATION",
-        "Romance" to "ROMANCE",
-        "Romancel" to "ROMANCEL",
-        "School Life" to "SCHOOL LIFE",
-        "Sci-Fi" to "SCI-FI",
-        "Seinen" to "SEINEN",
-        "Shoujo" to "SHOUJO",
-        "Shoujo Ai" to "SHOUJO AI",
-        "Shounen" to "SHOUNEN",
-        "Shounen Ai" to "SHOUNEN AI",
-        "Slice of Life" to "SLICE OF LIFE",
-        "Smut" to "SMUT",
-        "Sports" to "SPORTS",
-        "Supernatural" to "SUPERNATURAL",
-        "System" to "SYSTEM",
-        "Thriller" to "THRILLER",
-        "Tragedy" to "TRAGEDY",
-        "Urban" to "URBAN",
-        "Video Games" to "VIDEO GAMES",
-        "War" to "WAR",
-        "Wuxia" to "WUXIA",
-        "Xianxia" to "XIANXIA",
-        "Xuanhuan" to "XUANHUAN",
-        "Yaoi" to "YAOI",
-        "Yuri" to "YURI",
-    )
-
-    override val orderBys = listOf(
-        "Last" to "LASTEST",
+        "Action" to "action",
+        "Adult" to "adult",
+        "Adventure" to "adventure",
+        "Adventurei" to "adventurei",
+        "Anime & Comics" to "anime & comics",
+        "Comedy" to "comedy",
+        "Drama" to "drama",
+        "Eastern" to "eastern",
+        "Ecchi" to "ecchi",
+        "Fan-fiction" to "fan-fiction",
+        "Fantasy" to "fantasy",
+        "Game" to "game",
+        "Gender Bender" to "gender bender",
+        "Harem" to "harem",
+        "Historical" to "historical",
+        "Horror" to "horror",
+        "Isekai" to "isekai",
+        "Josei" to "josei",
+        "LGBT+" to "lgbt+",
+        "LitRPG" to "litrpg",
+        "Magic" to "magic",
+        "Magical Realism" to "magical realism",
+        "Martial Arts" to "martial arts",
+        "Mature" to "mature",
+        "Mecha" to "mecha",
+        "Military" to "military",
+        "Modern Life" to "modern life",
+        "Mystery" to "mystery",
+        "Other" to "other",
+        "Psychological" to "psychological",
+        "Realistic" to "realistic",
+        "Reincarnation" to "reincarnation",
+        "Romance" to "romance",
+        "Romancel" to "romancel",
+        "School Life" to "school life",
+        "Sci-Fi" to "sci-fi",
+        "Seinen" to "seinen",
+        "Shoujo" to "shoujo",
+        "Shoujo Ai" to "shoujo ai",
+        "Shounen" to "shounen",
+        "Shounen Ai" to "shounen ai",
+        "Slice of Life" to "slice of life",
+        "Smut" to "smut",
+        "Sports" to "sports",
+        "Supernatural" to "supernatural",
+        "System" to "system",
+        "Thriller" to "thriller",
+        "Tragedy" to "tragedy",
+        "Urban" to "urban",
+        "Video Games" to "video games",
+        "War" to "war",
+        "Wuxia" to "wuxia",
+        "Xianxia" to "xianxia",
+        "Xuanhuan" to "xuanhuan",
+        "Yaoi" to "yaoi",
+        "Yuri" to "yuri",
     )
 
 
@@ -102,18 +102,22 @@ open class NovelBinProvider : MainAPI() {
         tag: String?
     ): HeadMainPageResponse
     {
-        val url = "$mainUrl/api-web/novels?limit=30&page=$page&status=$mainCategory&sort=$orderBy&genre=$tag"
-        val document = app.get(url).parsed<MainPageResponse>()
+        val url = "$mainUrl/genre/$tag?sort=$mainCategory&page=$page"
+        val document = app.get(url).document
 
-        val returnValue = document.items.map { card ->
-            val href = "$mainUrl/novel/" + card.novelId
-            val title = card.novelName
+        val returnValue = document.select("article.site-panel.group.flex").mapNotNull { card ->
+            val href = card.selectFirst("a")?.attr("href") ?: return@mapNotNull null
+            val title = card.selectFirst("h2")?.text() ?: return@mapNotNull null
+
             newSearchResponse(
                 name = title,
                 url = href
             ) {
-                posterUrl = "https://images.novelarrow.com/novel_164_245/" + card.novelId + ".jpg"
+                posterUrl = fixUrlNull(
+                    card.selectFirst("img")?.attr("src")
+                )
             }
+
         }
         return HeadMainPageResponse(url, returnValue)
     }
@@ -149,7 +153,7 @@ open class NovelBinProvider : MainAPI() {
             this.synopsis = document.selectFirst("meta[name=description]")?.attr("content")
             this.author = document.selectFirst("meta[name=author]")?.attr("content")
             this.tags =
-                document.selectFirst("meta[name=category]")?.attr("content")?.let { listOf(it) }
+                document.selectFirst("meta[name=category]")?.attr("content")?.let { listOf(it.trim().lowercase().replaceFirstChar { char -> char.uppercase() }) }
             setStatus(document.selectFirst("meta[name=og:novel:status]")?.attr("content"))
             related = getRelated(document)
         }

--- a/app/src/main/java/com/lagradost/quicknovel/providers/NovelBinProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/NovelBinProvider.kt
@@ -132,7 +132,7 @@ open class NovelBinProvider : MainAPI() {
 
             newChapterData(
                 name = ch.chapterName,
-                url = "$mainUrl/chapter/$slug/${ch.chapterId}"
+                url = "$mainUrl/api-web/novels/$slug/chapters/${ch.chapterId}"
             )
         }
     }
@@ -191,22 +191,9 @@ open class NovelBinProvider : MainAPI() {
     }
 
     override suspend fun loadHtml(url: String): String {
-        val document = app.get(url).document
-        val script = document.select("script")
-            .firstOrNull {
-                it.data().contains("\\u003ch1\\u003e")
-            }?.data()
-            ?: error("No encontrado")
-
-        val raw = Regex(
-            """"((?:\\.|[^"])*)"""",
-            RegexOption.DOT_MATCHES_ALL
-        ).findAll(script)
-            .map { it.groupValues[1] }
-            .first { it.contains("\\u003ch1\\u003e") }
-
-        //I'm not sure if this is the right way to do it, or if there's already a function that does this.
-        return ObjectMapper().readValue("\"$raw\"", String::class.java)
+        val response = app.get(url).parsed<ChapterResponse>()
+        val content = response.item?.chapterInfo?.chapterContent ?:throw ErrorLoadingException("No content")
+        return content
     }
 
     override suspend fun search(query: String): List<SearchResponse> {
@@ -226,52 +213,63 @@ open class NovelBinProvider : MainAPI() {
     }
 
     data class MainPageResponse(
-        @JsonProperty("items") val items:List<NovelInfo>
+        @JsonProperty("items") val items: List<NovelInfo>
     )
+
     data class NovelInfo(
-        @JsonProperty("novel_name") val novelName:String,
-        @JsonProperty("novel_id") val novelId:String
+        @JsonProperty("novel_name") val novelName: String,
+        @JsonProperty("novel_id") val novelId: String
     )
 
     data class ChaptersResponse(
-        val items: List<ChapterInfo>,
-        val pagination: Pagination
+        @JsonProperty("items") val items: List<ChapterInfo>,
+        @JsonProperty("pagination") val pagination: Pagination
     )
 
     data class ChaptersResponseNested(
-        val items: List<List<ChapterInfo>>,
-        val pagination: Pagination
+        @JsonProperty("items") val items: List<List<ChapterInfo>>,
+        @JsonProperty("pagination") val pagination: Pagination
+    )
+
+    data class ChapterResponse(
+        @JsonProperty("item") val item: ChapterItemWrapper?
+    )
+
+    data class ChapterItemWrapper(
+        @JsonProperty("chapterInfo") val chapterInfo: ChapterInfo?
     )
 
     data class ChapterInfo(
         @JsonProperty("chapter_id")
-        val chapterId: String,
+        val chapterId: String?,
 
         @JsonProperty("chapter_name")
         val chapterName: String,
 
         @JsonProperty("platinum_content")
-        val platinum: Boolean,
+        val platinum: Boolean = false,
 
         @JsonProperty("premium_content")
-        val premium: Boolean,
+        val premium: Boolean = false,
 
         @JsonProperty("coin_price")
-        val coinPrice: Int,
+        val coinPrice: Int? = 0,
 
         @JsonProperty("comments_count")
-        val commentsCount: Int
+        val commentsCount: Int? = 0,
+
+        @JsonProperty("chapter_content")
+        val chapterContent: String?
     )
 
     data class Pagination(
-        val page: Int,
-        val limit: Int,
-        val total: Int,
-        val totalPages: Int
+        @JsonProperty("page") val page: Int,
+        @JsonProperty("limit") val limit: Int,
+        @JsonProperty("total") val total: Int,
+        @JsonProperty("totalPages") val totalPages: Int
     )
 
-    data class ReviewResponse(@JsonProperty("items") val items: List<ReviewItem>?
-    )
+    data class ReviewResponse(@JsonProperty("items") val items: List<ReviewItem>?)
 
     data class ReviewItem(
         @JsonProperty("content") val content: String?,

--- a/app/src/main/java/com/lagradost/quicknovel/providers/NovelBuddyProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/NovelBuddyProvider.kt
@@ -27,10 +27,95 @@ class NovelBuddyProvider : MainAPI() {
     override val hasReviews = true
     var novelId = ""
     override val mainCategories = listOf(
-        "Popular (Month)" to "month",
-        "Popular (All Time)" to "all-time",
-        "Newest" to "latest-release",
-        "Completed" to "completed"
+        "Ongoing" to "ongoing",
+        "Completed" to "completed",
+        "Hiatus" to "hiatus",
+        "Cancelled" to "cancelled"
+    )
+    override val tags = listOf(
+        "All" to "",
+        "Action" to "action",
+        "ActionAdventure" to "actionadventure",
+        "Adult" to "adult",
+        "Adventure" to "adventure",
+        "Adventurei" to "adventurei",
+        "Comedy" to "comedy",
+        "Drama" to "drama",
+        "Eastern" to "eastern",
+        "Easterni" to "easterni",
+        "Ecchi" to "ecchi",
+        "Ecchi Fantasy" to "ecchi fantasy",
+        "Fan-Fiction" to "fan-fiction",
+        "Fantasy" to "fantasy",
+        "Gam" to "gam",
+        "Game" to "game",
+        "Games" to "games",
+        "Gender Bender" to "gender bender",
+        "Harem" to "harem",
+        "Historical" to "historical",
+        "Horror" to "horror",
+        "Isekai" to "isekai",
+        "Josei" to "josei",
+        "Light Novel" to "light novel",
+        "Lolicon" to "lolicon",
+        "Magic" to "magic",
+        "Martial Arts" to "martial arts",
+        "Martial ArtsReincarnation" to "martial artsreincarnation",
+        "Mature" to "mature",
+        "Mecha" to "mecha",
+        "Military" to "military",
+        "Modern Life" to "modern life",
+        "Movies" to "movies",
+        "Mystery" to "mystery",
+        "Psychologic" to "psychologic",
+        "Psychological" to "psychological",
+        "Reincarnatio" to "reincarnatio",
+        "Reincarnation" to "reincarnation",
+        "Romanc" to "romanc",
+        "Romance" to "romance",
+        "Romance.Adventure" to "romance.adventure",
+        "Romance.Harem" to "romance.harem",
+        "Romance.Smut" to "romance.smut",
+        "RomanceAction" to "romanceaction",
+        "RomanceAdventure" to "romanceadventure",
+        "RomanceHarem" to "romanceharem",
+        "Romancei" to "romancei",
+        "Romancel" to "romancel",
+        "Romancem" to "romancem",
+        "School Life" to "school life",
+        "Sci-fi" to "sci-fi",
+        "Seinen" to "seinen",
+        "Seinen Wuxia" to "seinen wuxia",
+        "Shoujo" to "shoujo",
+        "Shoujo Ai" to "shoujo ai",
+        "Shounen" to "shounen",
+        "Shounen Ai" to "shounen ai",
+        "Slice of Lif" to "slice of lif",
+        "Slice Of Life" to "slice of life",
+        "Slice of Lifel" to "slice of lifel",
+        "Smut" to "smut",
+        "Sports" to "sports",
+        "Superna" to "superna",
+        "Supernatural" to "supernatural",
+        "System" to "system",
+        "Thriller" to "thriller",
+        "Tragedy" to "tragedy",
+        "Urban" to "urban",
+        "Urban Life" to "urban life",
+        "Wuxia" to "wuxia",
+        "Xianxia" to "xianxia",
+        "Xuanhuan" to "xuanhuan",
+        "Yaoi" to "yaoi",
+        "Yuri" to "yuri"
+    )
+
+    override val orderBys = listOf(
+        "Default Order" to "",
+        "Latest Updated" to "latest",
+        "Most Popular" to "popular",
+        "Highest Rating" to "rating",
+        "Most Viewed" to "views",
+        "Most Chapters" to "chapters",
     )
 
     override suspend fun loadMainPage(
@@ -39,11 +124,17 @@ class NovelBuddyProvider : MainAPI() {
         orderBy: String?,
         tag: String?
     ): HeadMainPageResponse {
-        val url = "$apiUrl/search?top_views=$mainCategory&page=$page&limit=24"
-        val document = app.get(url).parsed<Root>()
+        val params = mutableListOf<Pair<String, String>>()
+        if (!tag.isNullOrBlank()) params.add("genres" to tag)
+        if (!mainCategory.isNullOrBlank()) params.add("status" to mainCategory)
+        if (!orderBy.isNullOrBlank()) params.add("sort" to orderBy)
 
+        val queryPath = params.joinToString("") { "${it.first}=${it.second}&" }
+        val url = "$apiUrl/search?${queryPath}page=$page"
+        println(url)
+        val response = app.get(url).parsed<Root>()
         return HeadMainPageResponse(url,
-            document.data.items.map { element ->
+            response.data.items.map { element ->
                 val title = element.name
                 val href = element.url
                 newSearchResponse(title, href) {
@@ -158,58 +249,24 @@ class NovelBuddyProvider : MainAPI() {
     )
 
     data class Root(
-        @JsonProperty("success") val success: Boolean,
         @JsonProperty("data") val data: Data,
-        @JsonProperty("message") val message: String,
     )
 
     data class Data(
         @JsonProperty("items") val items: List<Item>,
-        @JsonProperty("pagination") val pagination: Pagination,
     )
 
     data class Item(
         @JsonProperty("id") val id: String,
         @JsonProperty("url") val url: String,
         @JsonProperty("name") val name: String,
-        @JsonProperty("alt_name") val altName: String,
         @JsonProperty("slug") val slug: String,
-        @JsonProperty("cover") val cover: String,
+        @JsonProperty("cover") val cover: String?,
         @JsonProperty("status") val status: String,
         @JsonProperty("rating") val rating: Double,
-        @JsonProperty("stats") val stats: Stats,
-        @JsonProperty("updated_at") val updatedAt: String,
-        @JsonProperty("cv") val cv: Long,
-        @JsonProperty("latest_chapters") val latestChapters: List<LatestChapter>,
     )
 
-    data class Stats(
-        @JsonProperty("views") val views: Long,
-        @JsonProperty("bookmarks_count") val bookmarksCount: Long,
-        @JsonProperty("comments_count") val commentsCount: Long,
-        @JsonProperty("chapters_count") val chaptersCount: Long,
-        @JsonProperty("ratings_count") val ratingsCount: Long,
-        @JsonProperty("reviews_count") val reviewsCount: Long,
-    )
 
-    data class LatestChapter(
-        @JsonProperty("id") val id: String,
-        @JsonProperty("url") val url: String,
-        @JsonProperty("name") val name: String,
-        @JsonProperty("slug") val slug: String,
-        @JsonProperty("created_at") val createdAt: String,
-        @JsonProperty("updated_at") val updatedAt: String,
-        @JsonProperty("cv") val cv: Long,
-    )
-
-    data class Pagination(
-        @JsonProperty("total") val total: Long,
-        @JsonProperty("page") val page: Long,
-        @JsonProperty("limit") val limit: Long,
-        @JsonProperty("total_pages") val totalPages: Long,
-        @JsonProperty("has_next") val hasNext: Boolean,
-        @JsonProperty("has_previous") val hasPrevious: Boolean,
-    )
 
     data class ChaptersApiResponse(
         @JsonProperty("success") val success: Boolean,

--- a/app/src/main/java/com/lagradost/quicknovel/providers/NovelBuddyProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/NovelBuddyProvider.kt
@@ -18,22 +18,22 @@ import org.jsoup.Jsoup
 
 class NovelBuddyProvider : MainAPI() {
     override val name = "Novel Buddy"
-    override val mainUrl = "https://novelbuddy.com"
-    private val apiUrl = "https://api.novelbuddy.com/titles"
+    override val mainUrl = "https://novelbuddy.me"
+    private val apiUrl = "https://api.novelbuddy.me/titles"
     override val iconId = R.drawable.icon_novelbuddy
     override val iconBackgroundId = R.color.novelBuddyColor
     override val lang = "en"
     override val hasMainPage = true
     override val hasReviews = true
     var novelId = ""
+    /*
     override val mainCategories = listOf(
         "Ongoing" to "ongoing",
         "Completed" to "completed",
         "Hiatus" to "hiatus",
         "Cancelled" to "cancelled"
-    )
+    )*/
     override val tags = listOf(
-        "All" to "",
         "Action" to "action",
         "ActionAdventure" to "actionadventure",
         "Adult" to "adult",
@@ -130,8 +130,7 @@ class NovelBuddyProvider : MainAPI() {
         if (!orderBy.isNullOrBlank()) params.add("sort" to orderBy)
 
         val queryPath = params.joinToString("") { "${it.first}=${it.second}&" }
-        val url = "$apiUrl/search?${queryPath}page=$page"
-        println(url)
+        val url = "$apiUrl/search?${queryPath}page=$page&limit=24"
         val response = app.get(url).parsed<Root>()
         return HeadMainPageResponse(url,
             response.data.items.map { element ->
@@ -144,7 +143,7 @@ class NovelBuddyProvider : MainAPI() {
     }
 
     override suspend fun load(url: String): LoadResponse {
-        val document = app.get(url).document
+        val document = app.get(url.replaceFirst("y.com","y.me")).document
 
         val jsonData = document.selectFirst("script#__NEXT_DATA__")?.data()
             ?: throw Exception("Invalid data")

--- a/app/src/main/java/com/lagradost/quicknovel/providers/NovelBuddyProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/NovelBuddyProvider.kt
@@ -6,11 +6,15 @@ import com.lagradost.quicknovel.LoadResponse
 import com.lagradost.quicknovel.MainAPI
 import com.lagradost.quicknovel.R
 import com.lagradost.quicknovel.SearchResponse
+import com.lagradost.quicknovel.UserReview
+import com.lagradost.quicknovel.fixUrlNull
 import com.lagradost.quicknovel.newChapterData
 import com.lagradost.quicknovel.newSearchResponse
 import com.lagradost.quicknovel.newStreamResponse
+import com.lagradost.quicknovel.providers.NovelFireProvider.PostsResponse
 import com.lagradost.quicknovel.setStatus
 import com.lagradost.quicknovel.util.AppUtils.parseJson
+import org.jsoup.Jsoup
 
 class NovelBuddyProvider : MainAPI() {
     override val name = "Novel Buddy"
@@ -20,7 +24,8 @@ class NovelBuddyProvider : MainAPI() {
     override val iconBackgroundId = R.color.novelBuddyColor
     override val lang = "en"
     override val hasMainPage = true
-
+    override val hasReviews = true
+    var novelId = ""
     override val mainCategories = listOf(
         "Popular (Month)" to "month",
         "Popular (All Time)" to "all-time",
@@ -55,7 +60,7 @@ class NovelBuddyProvider : MainAPI() {
 
         val nextData = parseJson<NextData>(jsonData)
         val bookId = nextData.props.pageProps.initialManga.id
-
+        novelId = bookId
         val title = nextData.props.pageProps.initialManga.name
 
         val api = "$apiUrl/$bookId/chapters"
@@ -78,6 +83,30 @@ class NovelBuddyProvider : MainAPI() {
         }
     }
 
+    //https://api.novelbuddy.com/comments/title/WAY3xDyr?page=1&limit=10&sort=newest&skip_reactions=1
+    override suspend fun loadReviews(
+        url: String,
+        page: Int,
+        showSpoilers: Boolean
+    ): List<UserReview> {
+        if (novelId.isEmpty()) return emptyList()
+        val realUrl = "${apiUrl.replace("/titles", "")}/comments/title/$novelId?page=$page&limit=10&sort=newest&skip_reactions=1"
+        val res = app.get(realUrl).parsedSafe<CommentResponse>()
+        val data = res?.data ?: return emptyList()
+        return data.items?.map { item ->
+            val reviewTxt = item.content ?: ""
+
+            val date = item.createdAt?.replace("T", " ")
+
+            UserReview(
+                review = reviewTxt,
+                username = item.user?.name ?: "Guest",
+                reviewDate = date,
+                avatarUrl = fixUrlNull(item.user?.avatar),
+            )
+        } ?: emptyList()
+    }
+
     override suspend fun loadHtml(url: String): String? {
         val document = app.get(url).document
         val content = document.selectFirst("div.novel-tts-content") ?: return null
@@ -98,117 +127,128 @@ class NovelBuddyProvider : MainAPI() {
         }
     }
 
-
     data class NextData(
-        val props: NextProps
+        @JsonProperty("props") val props: NextProps
     )
 
     data class NextProps(
-        val pageProps: NextPageProps
+        @JsonProperty("pageProps") val pageProps: NextPageProps
     )
 
     data class NextPageProps(
-        val initialManga: InitialManga
+        @JsonProperty("initialManga") val initialManga: InitialManga
     )
 
     data class InitialManga(
-        val id: String,
-        val name: String,
-        val cover: String,
-        val summary: String,
-        val status: String,
-        val authors: List<Author>,
-        val genres: List<Genre>
+        @JsonProperty("id") val id: String,
+        @JsonProperty("name") val name: String,
+        @JsonProperty("cover") val cover: String,
+        @JsonProperty("summary") val summary: String,
+        @JsonProperty("status") val status: String,
+        @JsonProperty("authors") val authors: List<Author>,
+        @JsonProperty("genres") val genres: List<Genre>
     )
 
-    data class Author(val name: String)
-    data class Genre(val name: String)
+    data class Author(
+        @JsonProperty("name") val name: String
+    )
 
+    data class Genre(
+        @JsonProperty("name") val name: String
+    )
 
     data class Root(
-        val success: Boolean,
-        val data: Data,
-        val message: String,
+        @JsonProperty("success") val success: Boolean,
+        @JsonProperty("data") val data: Data,
+        @JsonProperty("message") val message: String,
     )
 
     data class Data(
-        val items: List<Item>,
-        val pagination: Pagination,
+        @JsonProperty("items") val items: List<Item>,
+        @JsonProperty("pagination") val pagination: Pagination,
     )
 
     data class Item(
-        val id: String,
-        val url: String,
-        val name: String,
-        @JsonProperty("alt_name")
-        val altName: String,
-        val slug: String,
-        val cover: String,
-        val status: String,
-        val rating: Double,
-        val stats: Stats,
-        @JsonProperty("updated_at")
-        val updatedAt: String,
-        val cv: Long,
-        @JsonProperty("latest_chapters")
-        val latestChapters: List<LatestChapter>,
+        @JsonProperty("id") val id: String,
+        @JsonProperty("url") val url: String,
+        @JsonProperty("name") val name: String,
+        @JsonProperty("alt_name") val altName: String,
+        @JsonProperty("slug") val slug: String,
+        @JsonProperty("cover") val cover: String,
+        @JsonProperty("status") val status: String,
+        @JsonProperty("rating") val rating: Double,
+        @JsonProperty("stats") val stats: Stats,
+        @JsonProperty("updated_at") val updatedAt: String,
+        @JsonProperty("cv") val cv: Long,
+        @JsonProperty("latest_chapters") val latestChapters: List<LatestChapter>,
     )
 
     data class Stats(
-        val views: Long,
-        @JsonProperty("bookmarks_count")
-        val bookmarksCount: Long,
-        @JsonProperty("comments_count")
-        val commentsCount: Long,
-        @JsonProperty("chapters_count")
-        val chaptersCount: Long,
-        @JsonProperty("ratings_count")
-        val ratingsCount: Long,
-        @JsonProperty("reviews_count")
-        val reviewsCount: Long,
+        @JsonProperty("views") val views: Long,
+        @JsonProperty("bookmarks_count") val bookmarksCount: Long,
+        @JsonProperty("comments_count") val commentsCount: Long,
+        @JsonProperty("chapters_count") val chaptersCount: Long,
+        @JsonProperty("ratings_count") val ratingsCount: Long,
+        @JsonProperty("reviews_count") val reviewsCount: Long,
     )
 
     data class LatestChapter(
-        val id: String,
-        val url: String,
-        val name: String,
-        val slug: String,
-        @JsonProperty("created_at")
-        val createdAt: String,
-        @JsonProperty("updated_at")
-        val updatedAt: String,
-        val cv: Long,
+        @JsonProperty("id") val id: String,
+        @JsonProperty("url") val url: String,
+        @JsonProperty("name") val name: String,
+        @JsonProperty("slug") val slug: String,
+        @JsonProperty("created_at") val createdAt: String,
+        @JsonProperty("updated_at") val updatedAt: String,
+        @JsonProperty("cv") val cv: Long,
     )
 
     data class Pagination(
-        val total: Long,
-        val page: Long,
-        val limit: Long,
-        @JsonProperty("total_pages")
-        val totalPages: Long,
-        @JsonProperty("has_next")
-        val hasNext: Boolean,
-        @JsonProperty("has_previous")
-        val hasPrevious: Boolean,
+        @JsonProperty("total") val total: Long,
+        @JsonProperty("page") val page: Long,
+        @JsonProperty("limit") val limit: Long,
+        @JsonProperty("total_pages") val totalPages: Long,
+        @JsonProperty("has_next") val hasNext: Boolean,
+        @JsonProperty("has_previous") val hasPrevious: Boolean,
     )
 
     data class ChaptersApiResponse(
-        val success: Boolean,
-        val data: ChaptersData,
-        val message: String,
+        @JsonProperty("success") val success: Boolean,
+        @JsonProperty("data") val data: ChaptersData,
+        @JsonProperty("message") val message: String,
     )
 
     data class ChaptersData(
-        val chapters: List<Chapter>,
+        @JsonProperty("chapters") val chapters: List<Chapter>,
     )
 
     data class Chapter(
-        val id: String,
-        val url: String,
-        val name: String,
-        val slug: String,
-        @JsonProperty("updated_at")
-        val updatedAt: String,
-        val cv: Long,
+        @JsonProperty("id") val id: String,
+        @JsonProperty("url") val url: String,
+        @JsonProperty("name") val name: String,
+        @JsonProperty("slug") val slug: String,
+        @JsonProperty("updated_at") val updatedAt: String,
+        @JsonProperty("cv") val cv: Long,
+    )
+
+    data class CommentResponse(
+        @JsonProperty("success") val success: Boolean? = null,
+        @JsonProperty("data") val data: CommentData? = null
+    )
+
+    data class CommentData(
+        @JsonProperty("items") val items: List<CommentItem>? = null,
+        @JsonProperty("next_cursor") val nextCursor: String? = null,
+        @JsonProperty("has_more") val hasMore: Boolean? = null
+    )
+
+    data class CommentItem(
+        @JsonProperty("content") val content: String? = null,
+        @JsonProperty("user") val user: CommentUser? = null,
+        @JsonProperty("created_at") val createdAt: String? = null,
+    )
+
+    data class CommentUser(
+        @JsonProperty("name") val name: String? = null,
+        @JsonProperty("avatar") val avatar: String? = null
     )
 }

--- a/app/src/main/java/com/lagradost/quicknovel/providers/NovelBuddyProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/NovelBuddyProvider.kt
@@ -15,6 +15,7 @@ import com.lagradost.quicknovel.providers.NovelFireProvider.PostsResponse
 import com.lagradost.quicknovel.setStatus
 import com.lagradost.quicknovel.util.AppUtils.parseJson
 import org.jsoup.Jsoup
+import java.util.concurrent.ConcurrentHashMap
 
 class NovelBuddyProvider : MainAPI() {
     override val name = "Novel Buddy"
@@ -25,7 +26,8 @@ class NovelBuddyProvider : MainAPI() {
     override val lang = "en"
     override val hasMainPage = true
     override val hasReviews = true
-    var novelId = ""
+    val novelsIdRequired = ConcurrentHashMap<String, String>()
+
     /*
     override val mainCategories = listOf(
         "Ongoing" to "ongoing",
@@ -150,7 +152,7 @@ class NovelBuddyProvider : MainAPI() {
 
         val nextData = parseJson<NextData>(jsonData)
         val bookId = nextData.props.pageProps.initialManga.id
-        novelId = bookId
+        novelsIdRequired[url] = bookId
         val title = nextData.props.pageProps.initialManga.name
 
         val api = "$apiUrl/$bookId/chapters"
@@ -179,8 +181,8 @@ class NovelBuddyProvider : MainAPI() {
         page: Int,
         showSpoilers: Boolean
     ): List<UserReview> {
-        if (novelId.isEmpty()) return emptyList()
-        val realUrl = "${apiUrl.replace("/titles", "")}/comments/title/$novelId?page=$page&limit=10&sort=newest&skip_reactions=1"
+
+        val realUrl = "${apiUrl.replace("/titles", "")}/comments/title/${novelsIdRequired[url]}?page=$page&limit=10&sort=newest&skip_reactions=1"
         val res = app.get(realUrl).parsedSafe<CommentResponse>()
         val data = res?.data ?: return emptyList()
         return data.items?.map { item ->

--- a/app/src/main/java/com/lagradost/quicknovel/providers/NovelFireProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/NovelFireProvider.kt
@@ -136,10 +136,8 @@ open class NovelFireProvider:  MainAPI() {
 
         val title = infoDiv.selectFirst("h1.novel-title")?.text() ?: throw ErrorLoadingException("Title not found")
 
+        novelId = document.selectFirst("a#novel-report")?.attr("report-post_id") ?: throw ErrorLoadingException("Id not found")
         val chapters = getChapters(url)
-
-        novelId = document.selectFirst("a#novel-report")?.attr("report-post_id") ?: ""
-        nextPosts = ""
 
         return newStreamResponse(title,fixUrl(url), chapters) {
             this.author = infoDiv.selectFirst("div.author > a")?.text()
@@ -176,38 +174,42 @@ open class NovelFireProvider:  MainAPI() {
     }
 
     open suspend fun getChapters(url: String): List<ChapterData> {
-        val bookId = url.substringAfterLast("/book/").substringBefore("?").substringBefore("/")
-        val firstPageUrl = "$mainUrl/book/$bookId/chapters?page=1"
-        val document = app.get(firstPageUrl).document
+        val bookSlug = url.trimEnd('/').substringAfterLast("/")
+        val ajaxUrl = "$mainUrl/ajax/listChapterDataAjax"
+        val response = app.get(ajaxUrl, params = mapOf(
+            "draw" to "1",
+            "columns[0][data]" to "n_sort",
+            "columns[0][name]" to "cmm_posts_detail.n_sort",
+            "columns[0][searchable]" to "true",
+            "columns[0][orderable]" to "true",
+            "columns[0][search][value]" to "",
+            "columns[0][search][regex]" to "false",
+            "columns[1][data]" to "bookmark_created_at",
+            "columns[1][name]" to "bookmark_chapters.created_at",
+            "columns[1][searchable]" to "false",
+            "columns[1][orderable]" to "true",
+            "columns[1][search][value]" to "",
+            "columns[1][search][regex]" to "false",
+            "order[0][column]" to "0",
+            "order[0][dir]" to "asc",
+            "order[0][name]" to "cmm_posts_detail.n_sort",
+            "start" to "0",
+            "length" to "-1",
+            "search[value]" to "",
+            "search[regex]" to "false",
+            "post_id" to novelId,
+            "only_bookmark" to "false"
+        )).parsed<AjaxChapterRoot>()
 
-        val pagination = document.selectFirst("div.pagenav div.pagination-container nav ul.pagination")
-        if (pagination != null) {
-            val lastPageElement = pagination.select("li").let { it.getOrNull(it.size - 2) }
-            val lastPageNumber = lastPageElement?.text()?.toIntOrNull() ?: 1
+        return response.data?.mapNotNull { item ->
+            val nSort = item.nSort ?: return@mapNotNull null
 
-            val lastPageUrl = "$mainUrl/book/$bookId/chapters?page=$lastPageNumber"
-            val lastPageDoc = app.get(lastPageUrl).document
-            val lastChapterLink = lastPageDoc.select("ul.chapter-list li a").last()?.attr("href") ?: ""
-            val totalChapters = lastChapterLink.substringAfterLast("/chapter-").toIntOrNull()
-
-            if (totalChapters != null) {
-                return (1..totalChapters).map { chapterNumber ->
-                    val chapterUrl = "$mainUrl/book/$bookId/chapter-$chapterNumber"
-                    newChapterData("Chapter $chapterNumber", chapterUrl)
-                }
+            val rawTitle = item.title ?: "Chapter $nSort"
+            val chapterUrl = "$mainUrl/book/$bookSlug/chapter-$nSort"
+            newChapterData(rawTitle, chapterUrl) {
+                this.dateOfRelease = item.createdAt
             }
-        }
-
-        return document.select("ul.chapter-list li").mapNotNull { li ->
-            val a = li.selectFirst("a") ?: return@mapNotNull null
-            val name = a.selectFirst("span.chapter-title")?.text() ?: a.text()
-            val url = a.attr("href")
-            val date = li.selectFirst("span.chapter-update")?.text()
-
-            newChapterData(name, url) {
-                this.dateOfRelease = date
-            }
-        }
+        } ?: emptyList()
     }
 
     suspend fun getRelated(): List<SearchResponse> {
@@ -312,5 +314,15 @@ open class NovelFireProvider:  MainAPI() {
         val html: String,
         @JsonProperty("next_cursor")
         val nextCursor: String,
+    )
+
+    data class AjaxChapterRoot(
+        @JsonProperty("data") val data: List<AjaxChapterItem>? = null
+    )
+
+    data class AjaxChapterItem(
+        @JsonProperty("n_sort") val nSort: Int? = null,
+        @JsonProperty("title") val title: String? = null,
+        @JsonProperty("bookmark_created_at") val createdAt: String? = null
     )
 }

--- a/app/src/main/java/com/lagradost/quicknovel/providers/NovelFireProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/NovelFireProvider.kt
@@ -28,7 +28,6 @@ open class NovelFireProvider:  MainAPI() {
     override val hasMainPage = true
     override val hasReviews = true
     val novelsIdRequired = ConcurrentHashMap<String, String>()
-    var nextPosts: String = ""
     override val mainCategories = listOf(
         "All" to "status-all",
         "Completed" to "status-completed",
@@ -236,9 +235,11 @@ open class NovelFireProvider:  MainAPI() {
         page: Int,
         showSpoilers: Boolean
     ): List<UserReview> {
-        val realUrl = "$mainUrl/comment/show?post_id=${novelsIdRequired[url]}&chapter_id=&order_by=newest&cursor=$nextPosts"
+        val reviewData = novelsIdRequired[url]?.split("-!--")?:emptyList()
+        val realUrl = "$mainUrl/comment/show?post_id=${reviewData[0]}&chapter_id=&order_by=newest&cursor=${reviewData.getOrNull(1) ?: ""}"
         val res = app.get(realUrl).parsed<PostsResponse>()
-        nextPosts = res.nextCursor
+        if(res.nextCursor.isNotBlank())
+            novelsIdRequired[url] = reviewData[0] +"-!--"+res.nextCursor
         val reviews = Jsoup.parse(res.html).select("li:has(.comment-item)")
 
         return reviews.mapNotNull { r ->

--- a/app/src/main/java/com/lagradost/quicknovel/providers/NovelFireProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/NovelFireProvider.kt
@@ -17,6 +17,7 @@ import com.lagradost.quicknovel.newSearchResponse
 import com.lagradost.quicknovel.newStreamResponse
 import com.lagradost.quicknovel.setStatus
 import org.jsoup.Jsoup
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.roundToInt
 
 open class NovelFireProvider:  MainAPI() {
@@ -26,7 +27,7 @@ open class NovelFireProvider:  MainAPI() {
     override val rateLimitTime = 500L
     override val hasMainPage = true
     override val hasReviews = true
-    var novelId: String = ""
+    val novelsIdRequired = ConcurrentHashMap<String, String>()
     var nextPosts: String = ""
     override val mainCategories = listOf(
         "All" to "status-all",
@@ -136,7 +137,7 @@ open class NovelFireProvider:  MainAPI() {
 
         val title = infoDiv.selectFirst("h1.novel-title")?.text() ?: throw ErrorLoadingException("Title not found")
 
-        novelId = document.selectFirst("a#novel-report")?.attr("report-post_id") ?: throw ErrorLoadingException("Id not found")
+        novelsIdRequired[url] = document.selectFirst("a#novel-report")?.attr("report-post_id") ?: throw ErrorLoadingException("Id not found")
         val chapters = getChapters(url)
 
         return newStreamResponse(title,fixUrl(url), chapters) {
@@ -169,7 +170,7 @@ open class NovelFireProvider:  MainAPI() {
                     ?.toIntOrNull() ?: 0
             this.rating = document.selectFirst("div.rating strong.nub")?.text()
                 ?.toFloatOrNull()?.times(20)?.times(10)?.roundToInt()
-            related = getRelated()
+            related = getRelated(url)
         }
     }
 
@@ -197,7 +198,7 @@ open class NovelFireProvider:  MainAPI() {
             "length" to "-1",
             "search[value]" to "",
             "search[regex]" to "false",
-            "post_id" to novelId,
+            "post_id" to novelsIdRequired[url].toString(),
             "only_bookmark" to "false"
         )).parsed<AjaxChapterRoot>()
 
@@ -212,8 +213,8 @@ open class NovelFireProvider:  MainAPI() {
         } ?: emptyList()
     }
 
-    suspend fun getRelated(): List<SearchResponse> {
-        val url = "$mainUrl/ajax/novelYouMayLike?post_id=$novelId"
+    suspend fun getRelated(url: String): List<SearchResponse> {
+        val url = "$mainUrl/ajax/novelYouMayLike?post_id=${novelsIdRequired[url]}"
         val document = app.get(url).parsed<RelatedResponse>()
         return Jsoup.parse(document.html).select("li.novel-item").mapNotNull { element ->
             val href = element.selectFirst("a")?.attr("href") ?: return@mapNotNull null
@@ -235,7 +236,7 @@ open class NovelFireProvider:  MainAPI() {
         page: Int,
         showSpoilers: Boolean
     ): List<UserReview> {
-        val realUrl = "$mainUrl/comment/show?post_id=$novelId&chapter_id=&order_by=newest&cursor=$nextPosts"
+        val realUrl = "$mainUrl/comment/show?post_id=${novelsIdRequired[url]}&chapter_id=&order_by=newest&cursor=$nextPosts"
         val res = app.get(realUrl).parsed<PostsResponse>()
         nextPosts = res.nextCursor
         val reviews = Jsoup.parse(res.html).select("li:has(.comment-item)")

--- a/app/src/main/java/com/lagradost/quicknovel/providers/NovelFireProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/NovelFireProvider.kt
@@ -248,25 +248,16 @@ open class NovelFireProvider:  MainAPI() {
 
             val reviewContent = body?.selectFirst(".comment-text")
 
-            /*
             val isSpoiler = reviewContent?.attr("data-spoiler") == "1"
-            if (isSpoiler && !showSpoilers) {
-
-            }*/
+            if (!showSpoilers && isSpoiler == true) return@mapNotNull null
 
             val reviewTxt = reviewContent?.html()
 
-            val overallScore = null
-            val scoresData = ArrayList<Pair<Int, String>>()
-
             UserReview(
                 reviewTxt ?: return@mapNotNull null,
-                reviewTitle = null,
                 username = username,
-                reviewTime,
+                reviewDate = reviewTime,
                 avatarUrl = fixUrlNull(avatarUrl),
-                overallScore,
-                scoresData
             )
         }
     }

--- a/app/src/main/java/com/lagradost/quicknovel/providers/NovelFireProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/NovelFireProvider.kt
@@ -1,19 +1,22 @@
 package com.lagradost.quicknovel.providers
 
+import android.net.Uri
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.quicknovel.ChapterData
 import com.lagradost.quicknovel.ErrorLoadingException
 import com.lagradost.quicknovel.HeadMainPageResponse
 import com.lagradost.quicknovel.LoadResponse
 import com.lagradost.quicknovel.MainAPI
-import com.lagradost.quicknovel.MainActivity.Companion.app
 import com.lagradost.quicknovel.R
 import com.lagradost.quicknovel.SearchResponse
+import com.lagradost.quicknovel.UserReview
 import com.lagradost.quicknovel.fixUrl
 import com.lagradost.quicknovel.fixUrlNull
 import com.lagradost.quicknovel.newChapterData
 import com.lagradost.quicknovel.newSearchResponse
 import com.lagradost.quicknovel.newStreamResponse
 import com.lagradost.quicknovel.setStatus
+import org.jsoup.Jsoup
 import kotlin.math.roundToInt
 
 open class NovelFireProvider:  MainAPI() {
@@ -22,7 +25,9 @@ open class NovelFireProvider:  MainAPI() {
     override val iconId = R.drawable.icon_novelfire
     override val rateLimitTime = 500L
     override val hasMainPage = true
-
+    override val hasReviews = true
+    var novelId: String = ""
+    var nextPosts: String = ""
     override val mainCategories = listOf(
         "All" to "status-all",
         "Completed" to "status-completed",
@@ -133,6 +138,9 @@ open class NovelFireProvider:  MainAPI() {
 
         val chapters = getChapters(url)
 
+        novelId = document.selectFirst("a#novel-report")?.attr("report-post_id") ?: ""
+        nextPosts = ""
+
         return newStreamResponse(title,fixUrl(url), chapters) {
             this.author = infoDiv.selectFirst("div.author > a")?.text()
             this.posterUrl = fixUrlNull(document.selectFirst("figure.cover img")?.attr("src"))
@@ -163,7 +171,7 @@ open class NovelFireProvider:  MainAPI() {
                     ?.toIntOrNull() ?: 0
             this.rating = document.selectFirst("div.rating strong.nub")?.text()
                 ?.toFloatOrNull()?.times(20)?.times(10)?.roundToInt()
-
+            related = getRelated()
         }
     }
 
@@ -202,6 +210,67 @@ open class NovelFireProvider:  MainAPI() {
         }
     }
 
+    suspend fun getRelated(): List<SearchResponse> {
+        val url = "$mainUrl/ajax/novelYouMayLike?post_id=$novelId"
+        val document = app.get(url).parsed<RelatedResponse>()
+        return Jsoup.parse(document.html).select("li.novel-item").mapNotNull { element ->
+            val href = element.selectFirst("a")?.attr("href") ?: return@mapNotNull null
+            val title = element.selectFirst("h5")?.text() ?: return@mapNotNull null
+            newSearchResponse(
+                name = title,
+                url = href
+            ) {
+                posterUrl = fixUrlNull(
+                    element.selectFirst("img")?.attr("data-src")
+                        ?: element.selectFirst("img")?.attr("src")
+                )
+            }
+        }
+    }
+
+    override suspend fun loadReviews(
+        url: String,
+        page: Int,
+        showSpoilers: Boolean
+    ): List<UserReview> {
+        val realUrl = "$mainUrl/comment/show?post_id=$novelId&chapter_id=&order_by=newest&cursor=$nextPosts"
+        val res = app.get(realUrl).parsed<PostsResponse>()
+        nextPosts = res.nextCursor
+        val reviews = Jsoup.parse(res.html).select("li:has(.comment-item)")
+
+        return reviews.mapNotNull { r ->
+            val header = r.selectFirst("div.comment-header")
+            val body = r.selectFirst("div.comment-body")
+
+            val username = header?.selectFirst(".username")?.text()
+            val avatarUrl = header?.selectFirst("img.avatar")?.attr("src")
+            val reviewTime = header?.selectFirst(".post-date")?.text() // Ej: "11h", "1d"
+
+            val reviewContent = body?.selectFirst(".comment-text")
+
+            /*
+            val isSpoiler = reviewContent?.attr("data-spoiler") == "1"
+            if (isSpoiler && !showSpoilers) {
+
+            }*/
+
+            val reviewTxt = reviewContent?.html()
+
+            val overallScore = null
+            val scoresData = ArrayList<Pair<Int, String>>()
+
+            UserReview(
+                reviewTxt ?: return@mapNotNull null,
+                reviewTitle = null,
+                username = username,
+                reviewTime,
+                avatarUrl = fixUrlNull(avatarUrl),
+                overallScore,
+                scoresData
+            )
+        }
+    }
+
     fun normalize(text: String): String {
         return text
             .lowercase()
@@ -226,7 +295,7 @@ open class NovelFireProvider:  MainAPI() {
     }
 
     override suspend fun search(query: String): List<SearchResponse> {
-        val url = "$mainUrl/search/?keyword=$query&page=1"
+        val url = "$mainUrl/search/?keyword=${Uri.encode(query.trim()).replace("%20","+")}&page=1"
         val document = app.get(url).document
 
         return document.select("ul.novel-list.horizontal.col2.chapters li.novel-item").mapNotNull { element ->
@@ -239,4 +308,18 @@ open class NovelFireProvider:  MainAPI() {
             }
         }
     }
+
+    data class RelatedResponse(
+        @JsonProperty("html")
+        val html:String
+    )
+
+    data class PostsResponse(
+        @JsonProperty("has_more_pages")
+        val hasMore: Boolean,
+        @JsonProperty("html")
+        val html: String,
+        @JsonProperty("next_cursor")
+        val nextCursor: String,
+    )
 }

--- a/app/src/main/java/com/lagradost/quicknovel/providers/NovelLightProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/NovelLightProvider.kt
@@ -18,6 +18,8 @@ import com.lagradost.quicknovel.setStatus
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import com.lagradost.quicknovel.MainActivity.Companion.app
+import com.lagradost.quicknovel.UserReview
+import com.lagradost.quicknovel.providers.LightNovelWorldProvider.PostsResponse
 
 class NovelLightProvider:  MainAPI() {
     override val name = "Novel Light"
@@ -26,6 +28,8 @@ class NovelLightProvider:  MainAPI() {
     override val iconId = R.drawable.icon_novelight
     override val iconBackgroundId = R.color.novelightColor
     override val hasMainPage = true
+    override val hasReviews = true
+    var novelId = ""
 
     fun baseHeaders(url:String = "") =
         if(url.isNotEmpty())
@@ -87,6 +91,10 @@ class NovelLightProvider:  MainAPI() {
         val infoDiv = document.select("div.container > div.flex-content")
         val title = document.selectFirst("header h1")?.text() ?: throw ErrorLoadingException("Title not found")
 
+        val scriptData = document.selectFirst("#comments script")?.data() ?: ""
+        novelId = Regex("""const OBJECT_BY_COMMENT = (\d+);""").find(scriptData)?.groupValues?.get(1) ?: ""
+
+
         val chapters = getChapters(document)
         return newStreamResponse(title,fixUrl(url), chapters) {
             this.posterUrl = fixUrlNull(infoDiv.selectFirst("div.poster > img")?.attr("src"))
@@ -103,9 +111,47 @@ class NovelLightProvider:  MainAPI() {
             this.tags = infoDiv.selectFirst("div.block.mini-info > div > div.info")?.select("> a")?.mapNotNull {
                 it.text().trim().takeIf { text ->  !text.isEmpty() }
             }
+            related = getRelated(document)
         }
     }
 
+    private fun getRelated(dc: Document): List<SearchResponse>{
+        return dc.select("section.manga-list > div.swiper-container > div.swiper-wrapper a").mapNotNull { element ->
+            val href = element.attr("href") ?: return@mapNotNull null
+            val title = element.selectFirst("div.title")?.text() ?: return@mapNotNull null
+            newSearchResponse(
+                name = title,
+                url = href
+            ) {
+                posterUrl = fixUrlNull(element.selectFirst("img")?.attr("src"))
+            }
+        }
+    }
+
+    override suspend fun loadReviews(
+        url: String,
+        page: Int,
+        showSpoilers: Boolean
+    ): List<UserReview> {
+        if (novelId.isEmpty()) return emptyList()
+
+        //https://novelight.net/api/comments/?content_type=18&limit=20&object_id=308&page=1
+        val realUrl = "$mainUrl/api/comments/?content_type=18&limit=20&object_id=$novelId&page=$page"
+
+        val res = app.get(realUrl).parsedSafe<NovelLightReviewsResponse>()
+        val dataList = res?.results ?: return emptyList()
+
+        return dataList.map { item ->
+            val cleanDate = item.timeCreated?.replace("T", " ")
+
+            UserReview(
+                review = item.content ?: "",
+                username = item.userObject?.username ?: "User",
+                reviewDate = cleanDate,
+                avatarUrl = fixUrlNull(item.userObject?.avatar),
+            )
+        }
+    }
     override suspend fun loadHtml(url: String): String {
         val jsonResponse = app.get(
             url = ajaxUrl + "/${url.substringAfterLast("/book/chapter/")}",
@@ -139,6 +185,23 @@ class NovelLightProvider:  MainAPI() {
     data class ChapterResponse(
         @JsonProperty("html")
         val html: String,
+    )
+
+    data class NovelLightReviewsResponse(
+        @JsonProperty("results") val results: List<ReviewItem>? = null,
+        @JsonProperty("count") val count: Int? = null
+    )
+
+    data class ReviewItem(
+        @JsonProperty("content") val content: String? = null,
+        @JsonProperty("time_created") val timeCreated: String? = null,
+        @JsonProperty("user_object") val userObject: ReviewUser? = null,
+        @JsonProperty("rating") val rating: Int? = null
+    )
+
+    data class ReviewUser(
+        @JsonProperty("username") val username: String? = null,
+        @JsonProperty("avatar") val avatar: String? = null
     )
 }
 

--- a/app/src/main/java/com/lagradost/quicknovel/providers/NovelLightProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/NovelLightProvider.kt
@@ -20,6 +20,7 @@ import org.jsoup.nodes.Document
 import com.lagradost.quicknovel.MainActivity.Companion.app
 import com.lagradost.quicknovel.UserReview
 import com.lagradost.quicknovel.providers.LightNovelWorldProvider.PostsResponse
+import java.util.concurrent.ConcurrentHashMap
 
 class NovelLightProvider:  MainAPI() {
     override val name = "Novel Light"
@@ -29,7 +30,7 @@ class NovelLightProvider:  MainAPI() {
     override val iconBackgroundId = R.color.novelightColor
     override val hasMainPage = true
     override val hasReviews = true
-    var novelId = ""
+    val novelsIdRequired = ConcurrentHashMap<String, String>()
 
     fun baseHeaders(url:String = "") =
         if(url.isNotEmpty())
@@ -92,7 +93,7 @@ class NovelLightProvider:  MainAPI() {
         val title = document.selectFirst("header h1")?.text() ?: throw ErrorLoadingException("Title not found")
 
         val scriptData = document.selectFirst("#comments script")?.data() ?: ""
-        novelId = Regex("""const OBJECT_BY_COMMENT = (\d+);""").find(scriptData)?.groupValues?.get(1) ?: ""
+        novelsIdRequired[url] = Regex("""const OBJECT_BY_COMMENT = (\d+);""").find(scriptData)?.groupValues?.get(1) ?: ""
 
 
         val chapters = getChapters(document)
@@ -133,10 +134,9 @@ class NovelLightProvider:  MainAPI() {
         page: Int,
         showSpoilers: Boolean
     ): List<UserReview> {
-        if (novelId.isEmpty()) return emptyList()
 
         //https://novelight.net/api/comments/?content_type=18&limit=20&object_id=308&page=1
-        val realUrl = "$mainUrl/api/comments/?content_type=18&limit=20&object_id=$novelId&page=$page"
+        val realUrl = "$mainUrl/api/comments/?content_type=18&limit=20&object_id=${novelsIdRequired[url]}&page=$page"
 
         val res = app.get(realUrl).parsedSafe<NovelLightReviewsResponse>()
         val dataList = res?.results ?: return emptyList()

--- a/app/src/main/java/com/lagradost/quicknovel/providers/NovelManiaProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/NovelManiaProvider.kt
@@ -1,18 +1,10 @@
 package com.lagradost.quicknovel.providers
 
 import android.net.Uri
-import com.lagradost.quicknovel.ChapterData
-import com.lagradost.quicknovel.ErrorLoadingException
-import com.lagradost.quicknovel.HeadMainPageResponse
-import com.lagradost.quicknovel.LoadResponse
-import com.lagradost.quicknovel.MainAPI
-import com.lagradost.quicknovel.MainActivity.Companion.app
-import com.lagradost.quicknovel.R
-import com.lagradost.quicknovel.SearchResponse
-import com.lagradost.quicknovel.newChapterData
-import com.lagradost.quicknovel.newSearchResponse
-import com.lagradost.quicknovel.newStreamResponse
-
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.lagradost.quicknovel.*
+import com.lagradost.quicknovel.util.AppUtils.parseJson
+import kotlin.collections.mapNotNull
 
 class NovelManiaProvider : MainAPI() {
 
@@ -29,87 +21,176 @@ class NovelManiaProvider : MainAPI() {
         orderBy: String?,
         tag: String?
     ): HeadMainPageResponse {
+        val url = "$mainUrl/api/novels?sort=title_asc&page=$page&items=24"
+        val document = app.get(url).parsed<SearchResponseNovelMania>()
 
-        val url = "$mainUrl/novels?page%5Bpage%5D=$page"
-        val document = app.get(url).document
-
-        val items = document.select("div.row div.top-novels").mapNotNull { card ->
-            val href = card.selectFirst("a")?.attr("href") ?: return@mapNotNull null
-            val title = card.selectFirst(".novel-title")?.text() ?: return@mapNotNull null
-
-            newSearchResponse(title, href) {
-                posterUrl = card.selectFirst("img")?.attr("src")
+        val items = document.data.mapNotNull { card ->
+            val title = card.title ?: return@mapNotNull null
+            return@mapNotNull newSearchResponse(title, "$mainUrl/novels/${card.slug}") {
+                posterUrl = card.cover?.large
             }
         }
 
         return HeadMainPageResponse(url, items)
     }
 
-    override suspend fun load(url: String): LoadResponse {
+    private suspend fun getChapters(url: String): List<ChapterData> {
+        //get /novels/slug
+        val relativePath = url.removePrefix(mainUrl).substringBefore("?source").removeSuffix("/")
+        val apiChaptersUrl = "$mainUrl/api${relativePath}/chapters?page=1&items=50&sort=asc"
+
+        val response = app.get(apiChaptersUrl).parsed<ChaptersResponse>()
+        val totalChapters = response.meta.count
+
+        //exist pagination
+        if (totalChapters > 50) {
+            return (0 until totalChapters).map {
+                newChapterData("Capítulo ${it + 1}", "$relativePath-------$it")
+            }
+        }
+
+        return response.data.map {
+            val title = if (it.longTitle.isNotBlank()) "${it.longTitle} - ${it.title}" else it.title
+            newChapterData(title, "$mainUrl${relativePath}/capitulos/${it.slug}")
+        }
+    }
+
+    override suspend fun load(url: String): LoadResponse? {
         val document = app.get(url).document
+        //contains novel info
+        val scriptContent = document.select("script[type=application/ld+json]")
+            .firstOrNull { it.html().contains("\"@type\":\"Book\"") }
+            ?.html() ?: return null
 
-        val title = document.selectFirst(".novel-info h1")?.text()  ?: throw ErrorLoadingException("Title not found")
+        val bookInfo = parseJson<NovelResponse>(scriptContent)
+        val chapters = getChapters(url)
 
-
-        // AUTHOR
-        var author: String? = null
-        document.select(".novel-info span b").forEach { b ->
-            if (b.text().contains("Autor")) {
-                val parent = b.parent()
-                b.remove()
-                author = parent?.text()?.trim()
-            }
+        return newStreamResponse(bookInfo.name, url, chapters) {
+            this.posterUrl = bookInfo.image
+            this.synopsis = bookInfo.description
+            this.author = bookInfo.author?.name
+            this.tags = bookInfo.genre
         }
+    }
 
-        val chapters = mutableListOf<ChapterData>()
-
-        val volumes = document.select("#accordion .card-header button")
-
-        volumes.forEach { volTag ->
-            val target = volTag.attr("data-target") // ej: #volume1
-
-            val chapterTags = document.select("$target li a[href]")
-
-            chapterTags.forEachIndexed { index, a ->
-                val name = a.selectFirst("strong")?.text()
-                    ?: "Chapter ${index + 1}"
-
-                val link = a.attr("href")
-
-                chapters.add(newChapterData("${volTag.text()} $name", link))
-            }
-        }
-
-        return newStreamResponse(title, url, chapters) {
-            this.posterUrl = document.selectFirst(".novel-img img")?.attr("src")
-            this.synopsis =  document.selectFirst("#info .text")?.text()
-            this.author = author
-            this.tags =  document.select("#info .tags a[href^=\"/genero/\"]")
-                .mapNotNull { it.attr("title") }
-        }
+    /**
+     * Returns the page containing the requested chapter and its index within that page.
+     *
+     * Requirements:
+     * 1. Pagination must be in ascending order.
+     * 2. The absolute Chapter Index must be provided (start at 0).
+     * 3. The number of items per page must be provided.
+     */
+    private fun getPaginationPositionAndRelativeIndexAscendant(chapterBigIndex: Int, itemsPerPage: Int): Pair<Int, Int> {
+        val page = (chapterBigIndex / itemsPerPage) + 1
+        val index = chapterBigIndex % itemsPerPage
+        return page to index
     }
 
     override suspend fun loadHtml(url: String): String? {
-        val document = app.get(url).document
+        val isPrediction = url.contains("-------")
 
-        val content = document.selectFirst("#chapter-content")
-            ?.children()
-            ?.joinToString("</br>") { it.outerHtml() }
+        val document = if (isPrediction) {
+            val chapterData = url.split("-------")
+            val relativePath = chapterData[0]
+            val absoluteChapterNumber = chapterData[1].toInt()
+            val itemsPerPage = 50
 
-        return content
+            val (page, index) = getPaginationPositionAndRelativeIndexAscendant(absoluteChapterNumber, itemsPerPage)
+
+            val apiRequestUrl = "${relativePath.replace("/novels/", "/api/novels/")}/chapters?page=$page&items=$itemsPerPage&sort=asc"
+            val response = app.get(apiRequestUrl).parsed<ChaptersResponse>()
+
+            val chapterSlug = response.data.getOrNull(index)?.slug ?: return null
+            val realChapterUrl = "${relativePath}/capitulos/$chapterSlug"
+            app.get(realChapterUrl).document
+        } else {
+            app.get(url).document
+        }
+
+        val scriptContent = document.select("script").firstOrNull {
+            it.data().contains("\$_TSR.router") && it.data().contains("content:")
+        }?.data() ?: return null
+
+        val contentRegex = Regex("""content:\s*"(.*?[^\\])"""")
+        val match = contentRegex.find(scriptContent)
+        val rawContent = match?.groupValues?.get(1) ?: return null
+
+        return decodeJSString(rawContent)
+    }
+
+    /**
+     * Decodes JavaScript escape sequences from a string.
+     * 1. Hexadecimal escapes (\xHH): e.g., \x3C -> <
+     * 2. Unicode escapes (\uHHHH): e.g., \u0026 -> &
+     * 3. Control/Special characters: e.g., \" -> ", \n -> newline, \\ -> \
+     */
+    //This function was generated by Android Studio Gemini
+    private fun decodeJSString(input: String): String {
+        var text = input
+
+        val hexRegex = Regex("""\\x([0-9a-fA-F]{2})""")
+        text = hexRegex.replace(text) {
+            it.groupValues[1].toInt(16).toChar().toString()
+        }
+
+        val unicodeRegex = Regex("""\\u([0-9a-fA-F]{4})""")
+        text = unicodeRegex.replace(text) {
+            it.groupValues[1].toInt(16).toChar().toString()
+        }
+
+        return text
+            .replace("\\\"", "\"")
+            .replace("\\n", "\n")
+            .replace("\\r", "")
+            .replace("\\\\", "\\")
     }
 
     override suspend fun search(query: String): List<SearchResponse> {
-        val url = "$mainUrl/novels?titulo=${Uri.encode(query)}"
-        val document = app.get(url).document
+        val url = "$mainUrl/api/novels?q=${Uri.encode(query)}&sort=popularity&limit=8"
+        val document = app.get(url).parsed<SearchResponseNovelMania>()
 
-        return document.select("div.row div.top-novels").mapNotNull { card ->
-            val href = card.selectFirst("a")?.attr("href") ?: return@mapNotNull null
-            val title = card.selectFirst(".novel-title")?.text() ?: return@mapNotNull null
-
-            newSearchResponse(title, href) {
-                posterUrl = card.selectFirst("img")?.attr("src")
+        return document.data.mapNotNull { card ->
+            val title = card.title ?: return@mapNotNull null
+            return@mapNotNull newSearchResponse(title, "$mainUrl/novels/${card.slug}") {
+                posterUrl = card.cover?.large
             }
         }
     }
+    data class NovelResponse(
+        @JsonProperty("name") val name: String,
+        @JsonProperty("description") val description: String?,
+        @JsonProperty("url") val url: String,
+        @JsonProperty("image") val image: String?,
+        @JsonProperty("author") val author: Author?,
+        @JsonProperty("genre") val genre: List<String>?
+    )
+
+    data class Author(@JsonProperty("name") val name: String)
+
+    data class ChaptersResponse(
+        @JsonProperty("data") val data: List<Chapter>,
+        @JsonProperty("meta") val meta: Meta,
+    )
+
+    data class Meta(@JsonProperty("count") val count: Int)
+
+    data class Chapter(
+        @JsonProperty("slug") val slug: String,
+        @JsonProperty("longTitle") val longTitle: String = "",
+        @JsonProperty("title") val title: String = ""
+    )
+
+
+    data class SearchResponseNovelMania(
+        @JsonProperty("data") val data: List<Novel>,
+    )
+    data class Novel(
+        @JsonProperty("cover") val cover: TypeImage?,
+        @JsonProperty("slug") val slug: String?,
+        @JsonProperty("title") val title: String?
+    )
+    data class TypeImage(
+        @JsonProperty("large") val large:String
+    )
 }

--- a/app/src/main/java/com/lagradost/quicknovel/providers/NovelasLigerasProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/NovelasLigerasProvider.kt
@@ -7,9 +7,11 @@ import com.lagradost.quicknovel.MainAPI
 import com.lagradost.quicknovel.R
 import com.lagradost.quicknovel.SearchResponse
 import com.lagradost.quicknovel.fixUrl
+import com.lagradost.quicknovel.fixUrlNull
 import com.lagradost.quicknovel.newChapterData
 import com.lagradost.quicknovel.newSearchResponse
 import com.lagradost.quicknovel.newStreamResponse
+import org.jsoup.nodes.Document
 
 class NovelasLigerasProvider : MainAPI() {
     override val name = "Nova"
@@ -91,6 +93,20 @@ class NovelasLigerasProvider : MainAPI() {
             this.synopsis = synopsis
             this.tags = infoDiv.select("div.product_meta span.tagged_as a").map {
                 it.text().trim()
+            }
+            related = getRelated(document)
+        }
+    }
+
+    private fun getRelated(dc: Document): List<SearchResponse>{
+        return dc.select("section.related > div > div > div").mapNotNull { element ->
+            val href = element.selectFirst("a")?.attr("href") ?: return@mapNotNull null
+            val title = element.selectFirst("h4")?.text() ?: return@mapNotNull null
+            newSearchResponse(
+                name = title,
+                url = href
+            ) {
+                posterUrl = fixUrlNull(element.selectFirst("img")?.attr("data-src"))
             }
         }
     }

--- a/app/src/main/java/com/lagradost/quicknovel/providers/PawReadProver.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/PawReadProver.kt
@@ -15,6 +15,7 @@ import com.lagradost.quicknovel.newSearchResponse
 import com.lagradost.quicknovel.newStreamResponse
 import com.lagradost.quicknovel.providers.NovelBuddyProvider.CommentResponse
 import org.jsoup.nodes.Document
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.roundToInt
 
 class PawReadProver : MainAPI() {
@@ -23,7 +24,7 @@ class PawReadProver : MainAPI() {
     override val iconId = R.drawable.pawread
     override val hasMainPage = true
     override val hasReviews = true
-    var novelId = ""
+    val novelsIdRequired = ConcurrentHashMap<String, String>()
     override val mainCategories = listOf(
         "All" to "all-",
         "Completed" to "wanjie-",
@@ -108,7 +109,7 @@ class PawReadProver : MainAPI() {
 
     override suspend fun load(url: String): LoadResponse {
         val document = app.get(url).document
-        novelId = document.selectFirst("input[name=novel_id]")?.attr("value") ?: ""
+        novelsIdRequired[url] = document.selectFirst("input[name=novel_id]")?.attr("value") ?: ""
         //val comic = document.selectFirst(".comic-view")
         val board = document.selectFirst("#tab1_board")!!
         val regex = Regex("'(\\d+)'")
@@ -160,9 +161,9 @@ class PawReadProver : MainAPI() {
         page: Int,
         showSpoilers: Boolean
     ): List<UserReview> {
-        if (novelId.isEmpty() || page > 1) return emptyList()
+        if (page > 1) return emptyList()
 
-        val realUrl = "https://api.pawread.com/user/review/list?access-token=undefined&novel_id=$novelId&chapter_id=0"
+        val realUrl = "https://api.pawread.com/user/review/list?access-token=undefined&novel_id=${novelsIdRequired[url]}&chapter_id=0"
 
         val res = app.get(realUrl).parsedSafe<PawReadReviewsResponse>()
         val dataList = res?.items ?: return emptyList()

--- a/app/src/main/java/com/lagradost/quicknovel/providers/PawReadProver.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/PawReadProver.kt
@@ -1,5 +1,6 @@
 package com.lagradost.quicknovel.providers
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.quicknovel.ErrorLoadingException
 import com.lagradost.quicknovel.HeadMainPageResponse
 import com.lagradost.quicknovel.LoadResponse
@@ -7,19 +8,22 @@ import com.lagradost.quicknovel.MainAPI
 import com.lagradost.quicknovel.MainActivity.Companion.app
 import com.lagradost.quicknovel.R
 import com.lagradost.quicknovel.SearchResponse
+import com.lagradost.quicknovel.UserReview
 import com.lagradost.quicknovel.fixUrlNull
 import com.lagradost.quicknovel.newChapterData
 import com.lagradost.quicknovel.newSearchResponse
 import com.lagradost.quicknovel.newStreamResponse
+import com.lagradost.quicknovel.providers.NovelBuddyProvider.CommentResponse
+import org.jsoup.nodes.Document
 import kotlin.math.roundToInt
 
 class PawReadProver : MainAPI() {
     override val name = "PawRead"
     override val mainUrl = "https://pawread.com"
     override val iconId = R.drawable.pawread
-
     override val hasMainPage = true
-
+    override val hasReviews = true
+    var novelId = ""
     override val mainCategories = listOf(
         "All" to "all-",
         "Completed" to "wanjie-",
@@ -104,7 +108,7 @@ class PawReadProver : MainAPI() {
 
     override suspend fun load(url: String): LoadResponse {
         val document = app.get(url).document
-
+        novelId = document.selectFirst("input[name=novel_id]")?.attr("value") ?: ""
         //val comic = document.selectFirst(".comic-view")
         val board = document.selectFirst("#tab1_board")!!
         val regex = Regex("'(\\d+)'")
@@ -135,9 +139,46 @@ class PawReadProver : MainAPI() {
                         attr?.attr("style") ?: ""
                     )?.groupValues?.get(1)
                 )
+            related = getRelated(document)
         }
     }
 
+    private fun getRelated(dc: Document): List<SearchResponse>{
+        return dc.select("div.comic-list > div.list-comic").mapNotNull { element ->
+            val href = element.selectFirst("h3 > a")?.attr("href") ?: return@mapNotNull null
+            val title = element.selectFirst("h3")?.text() ?: return@mapNotNull null
+            newSearchResponse(
+                name = title,
+                url = href
+            ) {
+                posterUrl = fixUrlNull(element.selectFirst("img")?.attr("src"))
+            }
+        }
+    }
+    override suspend fun loadReviews(
+        url: String,
+        page: Int,
+        showSpoilers: Boolean
+    ): List<UserReview> {
+        if (novelId.isEmpty() || page > 1) return emptyList()
+
+        val realUrl = "https://api.pawread.com/user/review/list?access-token=undefined&novel_id=$novelId&chapter_id=0"
+
+        val res = app.get(realUrl).parsedSafe<PawReadReviewsResponse>()
+        val dataList = res?.items ?: return emptyList()
+
+        return dataList.map { item ->
+            val reviewTxt = item.content?.joinToString("\n") ?: ""
+            UserReview(
+                review = reviewTxt,
+                reviewTitle = null,
+                username = item.user?.username ?: "Guest",
+                reviewDate = item.createdAt,
+                avatarUrl = fixUrlNull(item.user?.avatar),
+                rating = item.rating?.times(200),
+            )
+        }
+    }
     override suspend fun loadHtml(url: String): String? {
         val document = app.get(url).document
         val count = document.selectFirst("#countdown")
@@ -147,4 +188,21 @@ class PawReadProver : MainAPI() {
         val html = document.selectFirst("#chapter_item")!!.html()
         return html
     }
+
+    data class PawReadReviewsResponse(
+        @JsonProperty("items") val items: List<PawReadReviewItem>? = null,
+        @JsonProperty("status") val status: Int? = null
+    )
+
+    data class PawReadReviewItem(
+        @JsonProperty("content") val content: List<String>? = null, // Es una lista de párrafos
+        @JsonProperty("user") val user: PawReadUser? = null,
+        @JsonProperty("created_at") val createdAt: String? = null,
+        @JsonProperty("rating") val rating: Int? = null,
+    )
+
+    data class PawReadUser(
+        @JsonProperty("username") val username: String? = null,
+        @JsonProperty("avatar") val avatar: String? = null
+    )
 }

--- a/app/src/main/java/com/lagradost/quicknovel/providers/PawReadProver.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/PawReadProver.kt
@@ -130,7 +130,7 @@ class PawReadProver : MainAPI() {
             rating = document.select(".comic-score>span").getOrNull(1)?.text()?.toFloatOrNull()
                 ?.times(1000.0 / 5.0)?.roundToInt()
             peopleVoted = document.selectFirst("#scoreCount")?.text()?.toIntOrNull()
-            tags = document.select(".tags").map { it.text().trim().removePrefix("#").trim() }
+            tags = document.select("div.col-md-9 > div.mt20 > a.btn").map { it.text().trim().removePrefix("#").trim() }
             synopsis = document.selectFirst("#simple-des")?.text()
             val attr = board.selectFirst(">.col-md-3>div")
             posterUrl =

--- a/app/src/main/java/com/lagradost/quicknovel/providers/PlanetaEpubProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/PlanetaEpubProvider.kt
@@ -11,6 +11,7 @@ import com.lagradost.quicknovel.MainActivity.Companion.app
 import com.lagradost.quicknovel.R
 import com.lagradost.quicknovel.SearchResponse
 import com.lagradost.quicknovel.fixUrl
+import com.lagradost.quicknovel.fixUrlNull
 import com.lagradost.quicknovel.newEpubResponse
 import com.lagradost.quicknovel.newSearchResponse
 import org.jsoup.nodes.Document
@@ -152,8 +153,23 @@ class PlanetaEpubProvider :  MainAPI() {
             this.posterUrl = document.selectFirst("div.image-container > img")?.attr("src")
             this.synopsis =  document.selectFirst("#content > div:nth-child(2) > article > div > div.entry.themeform > div.entry-inner > div.descripcion-libro-premium > div:nth-child(2) > p")?.text() ?: ""
             this.author = titleContent.substringAfterLast("–")
+            related = getRelated(document)
         }
     }
+    private fun getRelated(dc: Document): List<SearchResponse>{
+        return dc.select("div#alxposts-2 > ul > li").mapNotNull { element ->
+            val href = element.selectFirst("a")?.attr("href") ?: return@mapNotNull null
+            val title = element.selectFirst("p.post-item-title")?.text() ?: return@mapNotNull null
+            newSearchResponse(
+                name = title,
+                url = href
+            ) {
+                posterUrl = element.selectFirst("img")?.attr("src")?.replace("-520x245","")
+            }
+        }
+    }
+
+
 
 
     override suspend fun search(query: String): List<SearchResponse> {

--- a/app/src/main/java/com/lagradost/quicknovel/providers/RanobesProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/RanobesProvider.kt
@@ -5,6 +5,7 @@ import com.lagradost.quicknovel.*
 import com.lagradost.quicknovel.util.AppUtils.parseJson
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import java.util.concurrent.ConcurrentHashMap
 
 
 class RanobesProvider : MainAPI() {
@@ -16,7 +17,8 @@ class RanobesProvider : MainAPI() {
     override val usesCloudFlareKiller = true
     override val rateLimitTime = 500L
     override val hasReviews = true
-    var novelId = ""
+    val novelsIdRequired = ConcurrentHashMap<String, String>()
+
     override val tags = listOf(
         "Action" to "Action",
         "Adult" to "Adult",
@@ -130,7 +132,7 @@ class RanobesProvider : MainAPI() {
 
     override suspend fun load(url: String): LoadResponse? {
         val document = app.get(url).document
-        novelId = document.selectFirst("input[name=newsid]")?.attr("value") ?: ""
+        novelsIdRequired[url] = document.selectFirst("input[name=newsid]")?.attr("value") ?: ""
         val name = document.selectFirst("h1.title")?.ownText() ?: return null
         val chapters = getChapters(document)
         return newStreamResponse(url = url, name = name, data = chapters) {
@@ -177,9 +179,7 @@ class RanobesProvider : MainAPI() {
         page: Int,
         showSpoilers: Boolean
     ): List<UserReview> {
-        if (novelId.isEmpty()) return emptyList()
-
-        val ajaxUrl = "$mainUrl/engine/ajax/controller.php?mod=comments&cstart=$page&news_id=$novelId&skin=Dark"
+        val ajaxUrl = "$mainUrl/engine/ajax/controller.php?mod=comments&cstart=$page&news_id=${novelsIdRequired[url]}&skin=Dark"
 
         val res = app.get(ajaxUrl).parsedSafe<RanobesCommentsResponse>()
         val htmlContent = res?.comments ?: return emptyList()

--- a/app/src/main/java/com/lagradost/quicknovel/providers/RanobesProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/RanobesProvider.kt
@@ -3,9 +3,7 @@ package com.lagradost.quicknovel.providers
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.quicknovel.*
 import com.lagradost.quicknovel.util.AppUtils.parseJson
-import com.lagradost.quicknovel.util.AppUtils.toJson
-import com.lagradost.quicknovel.util.AppUtils.tryParseJson
-import org.json.JSONObject
+import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 
 
@@ -17,6 +15,8 @@ class RanobesProvider : MainAPI() {
     override val iconBackgroundId = R.color.white
     override val usesCloudFlareKiller = true
     override val rateLimitTime = 500L
+    override val hasReviews = true
+    var novelId = ""
     override val tags = listOf(
         "Action" to "Action",
         "Adult" to "Adult",
@@ -130,6 +130,7 @@ class RanobesProvider : MainAPI() {
 
     override suspend fun load(url: String): LoadResponse? {
         val document = app.get(url).document
+        novelId = document.selectFirst("input[name=newsid]")?.attr("value") ?: ""
         val name = document.selectFirst("h1.title")?.ownText() ?: return null
         val chapters = getChapters(document)
         return newStreamResponse(url = url, name = name, data = chapters) {
@@ -154,9 +155,64 @@ class RanobesProvider : MainAPI() {
             val statusHeader =
                 document.selectFirst("li[title=Original status in: Chinese, Japanese, English, etc.] > span")
             setStatus(statusHeader?.text())
+            related = getRelated(document)
         }
     }
 
+    private fun getRelated(dc: Document): List<SearchResponse>{
+        return dc.select("div.tab-content > div.tab-pane > div.story_line").mapNotNull { element ->
+            val href = element.selectFirst("a")?.attr("href") ?: return@mapNotNull null
+            val title = element.selectFirst("span.title")?.text() ?: return@mapNotNull null
+            newSearchResponse(
+                name = title,
+                url = href
+            ) {
+                posterUrl = element.selectFirst("i.image.cover")?.attr("style")?.substringAfter(":url(")?.substringBefore(")")
+            }
+        }
+    }
+
+    override suspend fun loadReviews(
+        url: String,
+        page: Int,
+        showSpoilers: Boolean
+    ): List<UserReview> {
+        if (novelId.isEmpty()) return emptyList()
+
+        val ajaxUrl = "$mainUrl/engine/ajax/controller.php?mod=comments&cstart=$page&news_id=$novelId&skin=Dark"
+
+        val res = app.get(ajaxUrl).parsedSafe<RanobesCommentsResponse>()
+        val htmlContent = res?.comments ?: return emptyList()
+        val document = Jsoup.parse(htmlContent)
+
+        return document.select("div.comment").mapNotNull { item ->
+            val info = item.selectFirst("div.com_info")
+            val body = item.selectFirst("div.com_content")
+
+            val contentElement = body?.selectFirst("div.cont-text")
+
+            if (!showSpoilers) {
+                contentElement?.select(".spoiler-cont")?.remove()
+            }
+
+            val reviewTxt = contentElement?.text() ?: ""
+            if (reviewTxt.isBlank()) return@mapNotNull null
+
+            val scoreRaw = item.selectFirst("span.review-rating-num")?.text()?.toFloatOrNull()
+            val overallScore = scoreRaw?.times(200)?.toInt()
+
+            UserReview(
+                review = reviewTxt,
+                username = info?.selectFirst(".name")?.text() ?: "User",
+                reviewDate = info?.selectFirst("time")?.text(),
+                avatarUrl = fixUrlNull(info?.selectFirst(".avatar .cover")?.attr("style")
+                    ?.substringAfter("url(")
+                    ?.substringBefore(")")
+                    ?.replace("'", "")),
+                rating = overallScore,
+            )
+        }
+    }
 
     private fun getChapter(document: Document): List< String> {
         val script = document.selectFirst("script:containsData(window.__DATA__)")
@@ -263,5 +319,8 @@ class RanobesProvider : MainAPI() {
         val showDate: String?,
         @JsonProperty("link")
         val link: String,
+    )
+    data class RanobesCommentsResponse(
+        @JsonProperty("comments") val comments: String? = null
     )
 }

--- a/app/src/main/java/com/lagradost/quicknovel/providers/RanobesProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/RanobesProvider.kt
@@ -69,9 +69,6 @@ class RanobesProvider : MainAPI() {
 
         val returnValue = document.select("div.short-cont").mapNotNull { h ->
             val h2 = h.selectFirst("h2.title > a") ?: return@mapNotNull null
-            //val latestChap =
-            //    mainUrl + (h.nextElementSibling()?.selectFirst("div > a")?.attr("href")
-            //        ?: return@mapNotNull null)
             newSearchResponse(name = h2.text(), url = h2.attr("href") ?: return@mapNotNull null) {
                 posterUrl = fixUrlNull(
                     h.selectFirst("div.cont.showcont > div > a > figure")?.attr("style")
@@ -171,30 +168,41 @@ class RanobesProvider : MainAPI() {
         return parseJson<Root>(jsonString).chapters.map { it.link }.reversed()
     }
 
-    override suspend fun loadHtml(url: String): String? {
-        val chapterData = url.split("-------")
-        if (chapterData.size < 3) {
-            val dc = app.get(url, headers = baseHeaders).document
-            return (dc.selectFirst("#dle-content > article > div.block.story.shortstory > h1")
-                ?.html() ?: "") + (dc.selectFirst("#arrticle")?.html() ?: return null)
-        }
-
-        val baseUrl = chapterData[0].removeSuffix("/")
-        val chapterBigIndex = chapterData[1].toInt()
-        val totalChapters = chapterData[2].toInt()
-        val itemsPerPage = 25
-
+    private fun getPaginationPositionAndRelativeIndexDescendant(
+        arguments:List<String>,
+        itemsPerPage: Int
+    ): Pair<Int, Int> {
+        val chapterBigIndex = arguments[1].toInt()
+        val totalChapters = arguments[2].toInt()
         val totalPages = (totalChapters + itemsPerPage - 1) / itemsPerPage
 
         val page = (totalChapters - 1 - chapterBigIndex) / itemsPerPage + 1
 
-        val chaptersInLastPage = totalChapters % itemsPerPage.let { if (it == 0) itemsPerPage else it }
+        val chaptersInLastPage = totalChapters % itemsPerPage.let {
+            if (it == 0) itemsPerPage else it
+        }
 
         val index = if (page == totalPages) {
             chapterBigIndex % itemsPerPage
         } else {
             (chapterBigIndex - chaptersInLastPage) % itemsPerPage
         }
+
+        return page to index
+    }
+
+    override suspend fun loadHtml(url: String): String? {
+        val chapterData = url.split("-------")
+        if (chapterData.size < 3) {
+            val dc = app.get(url, headers = baseHeaders).document
+            return (dc.selectFirst("#dle-content > article > div.block.story.shortstory > h1")?.html() ?: "") +
+                    (dc.selectFirst("#arrticle")?.html() ?: return null)
+        }
+
+        val baseUrl = chapterData[0].removeSuffix("/")
+        val itemsPerPage = 25
+
+        val (page, index) = getPaginationPositionAndRelativeIndexDescendant(chapterData, itemsPerPage)
 
         val pageUrl = if (page <= 1) "$baseUrl/" else "$baseUrl/page/$page/"
         val document = app.get(pageUrl, headers = baseHeaders).document
@@ -205,15 +213,14 @@ class RanobesProvider : MainAPI() {
         val dc = app.get(chapterUrl, headers = baseHeaders).document
         val title = dc.selectFirst("#dle-content > article > div.block.story.shortstory > h1")?.html() ?: ""
         val content = dc.selectFirst("#arrticle") ?: return null
+
         content.select("img").forEach { img ->
             val src = img.attr("src")
-            if(src.isNotBlank()){
-                val fixedSrc = fixUrlNull(src)
-                if(fixedSrc != null){
-                    img.attr("src", fixedSrc)
-                }
+            if (src.isNotBlank()) {
+                fixUrlNull(src)?.let { fixed -> img.attr("src", fixed) }
             }
         }
+
         return title + content.html()
     }
 

--- a/app/src/main/java/com/lagradost/quicknovel/providers/ReadhiveProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/ReadhiveProvider.kt
@@ -21,56 +21,37 @@ class ReadhiveProvider  :  MainAPI() {
     override val rateLimitTime = 500L
 
     override val tags = listOf(
-        "All" to "",
-        "Abandoned Children" to "abandoned-children",
-        "Absent Parents" to "absent-parents",
-        "abusement" to "abusement",
-        "Abusive Characters" to "abusive-characters",
-        "Academy" to "academy",
-        "Accelerated Growth" to "accelerated-growth",
-        "Acting" to "acting",
-        "actor" to "actor",
-        "Adapted to Manhwa" to "adapted-to-manhwa",
-        "Adopted Children" to "adopted-children",
-        "Adopted Protagonist" to "adopted-protagonist",
-        "Adultery" to "adultery",
+        "Action" to "action",
+        "Adult" to "adult",
         "Adventure" to "adventure",
-        "Age Progression" to "age-progression",
-        "Age Regression" to "age-regression",
-        "Amnesia" to "amnesia",
-        "and Peasants" to "and-peasants",
-        "Animal Characteristics" to "animal-characteristics",
-        "Appearance Changes" to "appearance-changes",
-        "Appearance Different from Actual Age" to "appearance-different-from-actual-age",
-        "archduke" to "archduke",
-        "Aristocracy" to "aristocracy",
-        "Aristocrats" to "aristocrats",
-        "Army Building" to "army-building",
-        "Arranged Marriage" to "arranged-marriage",
-        "Arrogant Characters" to "arrogant-characters",
-        "Arrogant ML" to "arrogant-ml",
-        "Artifacts" to "artifacts",
-        "Artificial Intelligence" to "artificial-intelligence",
-        "Artists" to "artists",
-        "Assassins" to "assassins",
-        "baby" to "baby",
-        "Badass FL" to "badass-fl",
-        "Badass ML" to "badass-ml",
-        "beast" to "beast",
-        "Beasts" to "beasts",
-        "Beautiful Female Lead" to "beautiful-female-lead",
-        "Betrayal" to "betrayal",
-        "Bickering Couple" to "bickering-couple",
-        "bilateral salvation" to "bilateral-salvation",
         "BL" to "bl",
-        "BL. Yaoi" to "bl-yaoi",
-        "blood" to "blood",
-        "Bloodlines" to "bloodlines",
-        "blue-haired-fl" to "blue-haired-fl",
-        "Book Possessed" to "book-possessed",
-        "boss" to "boss",
-        "Boss-subordinate" to "boss-subordinate",
-        "Brainwashing" to "brainwashing"
+        "Boy's Love" to "boy's-love",
+        "Comedy" to "comedy",
+        "Drama" to "drama",
+        "Ecchi" to "ecchi",
+        "Fantasy" to "fantasy",
+        "Harem" to "harem",
+        "Historical" to "historical",
+        "Horror" to "horror",
+        "Josei" to "josei",
+        "Martial Arts" to "martial-arts",
+        "Mature" to "mature",
+        "Mecha" to "mecha",
+        "Mystery" to "mystery",
+        "Psychological" to "psychological",
+        "Reincarnation" to "reincarnation",
+        "Romance" to "romance",
+        "School Life" to "school-life",
+        "Sci-Fi" to "sci-fi",
+        "Shoujo" to "shoujo",
+        "Shounen Ai" to "shounen-ai",
+        "Slice of Life" to "slice-of-life",
+        "Sports" to "sports",
+        "Supernatural" to "supernatural",
+        "Tragedy" to "tragedy",
+        "Xianxia" to "xianxia",
+        "Xuanhuan" to "xuanhuan",
+        "Yaoi" to "yaoi"
     )
 
     override suspend fun loadMainPage(
@@ -80,7 +61,7 @@ class ReadhiveProvider  :  MainAPI() {
         tag: String?
     ): HeadMainPageResponse {
         val hasTag = !tag.isNullOrBlank()
-        val tagPath = if (hasTag) "tag/$tag/" else ""
+        val tagPath = if (hasTag) "genre/$tag/" else ""
 
         val url = "$mainUrl/${tagPath}page/$page/"
         val document = app.get(url).document
@@ -134,7 +115,7 @@ class ReadhiveProvider  :  MainAPI() {
 
             this.author = infoDiv.selectFirst("span.leading-7")?.text() ?: ""
 
-            this.tags = infoDiv.select("section.relative.grid.grid-cols-1.lg\\:grid-areas-series__body.lg\\:grid-cols-series.gap-x-4.px-4.py-2.sm\\:px-8 > div.lg\\:grid-in-content.mt-4 > div:nth-child(1) > div:nth-child(2) > div.flex.flex-wrap > a").mapNotNull {
+            this.tags = infoDiv.select("section.relative.grid.grid-cols-1.lg\\:grid-areas-series__body.lg\\:grid-cols-series.gap-x-4.px-4.py-2.sm\\:px-8 > div.lg\\:grid-in-info > div > a").mapNotNull {
                 it.text().trim().takeIf { text ->  !text.isEmpty() }
             }
             related = getRelated(document)

--- a/app/src/main/java/com/lagradost/quicknovel/providers/ReadhiveProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/ReadhiveProvider.kt
@@ -11,6 +11,7 @@ import com.lagradost.quicknovel.fixUrlNull
 import com.lagradost.quicknovel.newChapterData
 import com.lagradost.quicknovel.newSearchResponse
 import com.lagradost.quicknovel.newStreamResponse
+import org.jsoup.nodes.Document
 
 class ReadhiveProvider  :  MainAPI() {
     override val name = "ReadHive"
@@ -77,12 +78,26 @@ class ReadhiveProvider  :  MainAPI() {
         mainCategory: String?,
         orderBy: String?,
         tag: String?
-    ): HeadMainPageResponse
-    {
-        val url = "$mainUrl/${if(!tag.isNullOrBlank()) "genre/$tag/" else ""}page/$page/"
-        val document = app.get(url).document
+    ): HeadMainPageResponse {
+        val hasTag = !tag.isNullOrBlank()
+        val tagPath = if (hasTag) "tag/$tag/" else ""
 
-        val returnValue = document.select("a.peer").mapNotNull { card ->
+        val url = "$mainUrl/${tagPath}page/$page/"
+        val document = app.get(url).document
+        val returnValue = parsePageCards(document).toMutableList()
+
+        if (hasTag && page == 1) {
+            val nextUrl = "$mainUrl/${tagPath}page/2/"
+            val nextDocument = app.get(nextUrl).document
+            val secondPageCards = parsePageCards(nextDocument)
+            returnValue.addAll(secondPageCards)
+        }
+
+        return HeadMainPageResponse(url, returnValue)
+    }
+
+    private fun parsePageCards(document: Document): List<SearchResponse> {
+        return document.select("a.peer, a.col-span-2").mapNotNull { card ->
             val href = card?.attr("href") ?: return@mapNotNull null
             val title = card.selectFirst("img")?.attr("alt") ?: return@mapNotNull null
             newSearchResponse(
@@ -92,7 +107,6 @@ class ReadhiveProvider  :  MainAPI() {
                 posterUrl = fixUrlNull(card.selectFirst("img")?.attr("src"))
             }
         }
-        return HeadMainPageResponse(url, returnValue)
     }
 
 
@@ -122,6 +136,20 @@ class ReadhiveProvider  :  MainAPI() {
 
             this.tags = infoDiv.select("section.relative.grid.grid-cols-1.lg\\:grid-areas-series__body.lg\\:grid-cols-series.gap-x-4.px-4.py-2.sm\\:px-8 > div.lg\\:grid-in-content.mt-4 > div:nth-child(1) > div:nth-child(2) > div.flex.flex-wrap > a").mapNotNull {
                 it.text().trim().takeIf { text ->  !text.isEmpty() }
+            }
+            related = getRelated(document)
+        }
+    }
+
+    private fun getRelated(dc: Document): List<SearchResponse>{
+        return dc.select("div.swiper > div.swiper-wrapper > div.swiper-slide").mapNotNull { element ->
+            val href = element.selectFirst("a")?.attr("href") ?: return@mapNotNull null
+            val title = element.selectFirst("h6")?.text() ?: return@mapNotNull null
+            newSearchResponse(
+                name = title,
+                url = href
+            ) {
+                posterUrl = fixUrlNull(element.selectFirst("img")?.attr("src"))
             }
         }
     }

--- a/app/src/main/java/com/lagradost/quicknovel/providers/RoyalRoadProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/RoyalRoadProvider.kt
@@ -6,7 +6,6 @@ import com.lagradost.quicknovel.ErrorLoadingException
 import com.lagradost.quicknovel.HeadMainPageResponse
 import com.lagradost.quicknovel.LoadResponse
 import com.lagradost.quicknovel.MainAPI
-import com.lagradost.quicknovel.MainActivity.Companion.app
 import com.lagradost.quicknovel.R
 import com.lagradost.quicknovel.SearchResponse
 import com.lagradost.quicknovel.UserReview
@@ -27,9 +26,8 @@ class RoyalRoadProvider : MainAPI() {
     override val mainUrl = "https://www.royalroad.com"
     override val rateLimitTime = 500L
     override val hasMainPage = true
-
+    override val hasReviews = true
     override val iconId = R.drawable.big_icon_royalroad
-
     override val iconBackgroundId = R.color.royalRoadColor
 
     override val orderBys = listOf(
@@ -95,7 +93,6 @@ class RoyalRoadProvider : MainAPI() {
         "Tragedy" to "tragedy"
     ).sortedBy { it.first })
 
-    override val hasReviews = true
 
     @SuppressLint("SimpleDateFormat")
     override suspend fun loadReviews(

--- a/app/src/main/java/com/lagradost/quicknovel/providers/WattpadProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/WattpadProvider.kt
@@ -9,6 +9,7 @@ import org.json.JSONObject
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.parser.Parser
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.collections.mapNotNull
 
 class WattpadProvider : MainAPI() {
@@ -18,7 +19,7 @@ class WattpadProvider : MainAPI() {
     override val iconId = R.drawable.icon_wattpad
     override val iconBackgroundId = R.color.wattpadColor
     override val rateLimitTime = 500L
-    var novelId = ""
+    val novelsIdRequired = ConcurrentHashMap<String, String>()
 
     private val langHeaders = mapOf(
         "" to "en-US,en;q=0.9", // English default
@@ -173,9 +174,7 @@ class WattpadProvider : MainAPI() {
         page: Int,
         showSpoilers: Boolean
     ): List<UserReview> {
-        if (novelId.isEmpty()) return emptyList()
-
-        val realUrl = "$mainUrl/api/review/get?serie_id=$novelId&page=${page - 1}&sort=most_liked"
+        val realUrl = "$mainUrl/api/review/get?serie_id=${novelsIdRequired[url]}&page=${page - 1}&sort=most_liked"
         val res = app.get(realUrl).parsedSafe<ReviewResponse>()
 
         return res?.data?.mapNotNull { item ->

--- a/app/src/main/java/com/lagradost/quicknovel/providers/WattpadProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/WattpadProvider.kt
@@ -2,10 +2,12 @@ package com.lagradost.quicknovel.providers
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.quicknovel.*
+import com.lagradost.quicknovel.providers.WtrLabProvider.ReviewResponse
 import com.lagradost.quicknovel.util.AppUtils.parseJson
 import com.lagradost.quicknovel.util.AppUtils.toJson
 import org.json.JSONObject
 import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
 import org.jsoup.parser.Parser
 import kotlin.collections.mapNotNull
 
@@ -16,7 +18,7 @@ class WattpadProvider : MainAPI() {
     override val iconId = R.drawable.icon_wattpad
     override val iconBackgroundId = R.color.wattpadColor
     override val rateLimitTime = 500L
-
+    var novelId = ""
 
     private val langHeaders = mapOf(
         "" to "en-US,en;q=0.9", // English default
@@ -148,7 +150,43 @@ class WattpadProvider : MainAPI() {
             tags = story.tags?.mapNotNull {
                 it.trim().takeIf { text ->  text.isNotEmpty() }
             }
+            related = getRelated(response.document)
         }
+    }
+
+
+    private fun getRelated(dc: Document): List<SearchResponse>{
+        return dc.select("div[data-testid=similar-stories-slide-column] > a").mapNotNull { element ->
+            val href = element.attr("href") ?: return@mapNotNull null
+            val title = element.selectFirst("h5")?.text() ?: return@mapNotNull null
+            newSearchResponse(
+                name = title,
+                url = href
+            ) {
+                posterUrl = fixUrlNull(element.selectFirst("img")?.attr("src"))
+            }
+        }
+    }
+
+    override suspend fun loadReviews(
+        url: String,
+        page: Int,
+        showSpoilers: Boolean
+    ): List<UserReview> {
+        if (novelId.isEmpty()) return emptyList()
+
+        val realUrl = "$mainUrl/api/review/get?serie_id=$novelId&page=${page - 1}&sort=most_liked"
+        val res = app.get(realUrl).parsedSafe<ReviewResponse>()
+
+        return res?.data?.mapNotNull { item ->
+            val reviewTxt = item.comment ?: return@mapNotNull null
+            UserReview(
+                review = reviewTxt,
+                username = item.username ?: "User",
+                reviewDate = item.createdAt,
+                rating = item.rate?.times(200)
+            )
+        } ?: emptyList()
     }
 
     override suspend fun loadHtml(url: String): String {

--- a/app/src/main/java/com/lagradost/quicknovel/providers/WtrLabProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/WtrLabProvider.kt
@@ -9,12 +9,16 @@ import com.lagradost.quicknovel.LoadResponse
 import com.lagradost.quicknovel.MainAPI
 import com.lagradost.quicknovel.R
 import com.lagradost.quicknovel.SearchResponse
+import com.lagradost.quicknovel.UserReview
 import com.lagradost.quicknovel.fixUrlNull
 import com.lagradost.quicknovel.newChapterData
 import com.lagradost.quicknovel.newSearchResponse
 import com.lagradost.quicknovel.newStreamResponse
+import com.lagradost.quicknovel.providers.NovelFireProvider.PostsResponse
+import com.lagradost.quicknovel.providers.NovelFireProvider.RelatedResponse
 import com.lagradost.quicknovel.setStatus
 import com.lagradost.quicknovel.util.AppUtils.parseJson
+import org.jsoup.Jsoup
 import javax.crypto.Cipher
 import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.SecretKeySpec
@@ -27,9 +31,9 @@ class  WtrLabProvider : MainAPI() {
     override val lang = "en"
     override val iconId = R.drawable.icon_wtrlab
     override val hasMainPage = true
-    override val hasReviews = false
     override val usesCloudFlareKiller = true
-
+    override val hasReviews = true
+    var novelId = ""
     //&status=
     override val mainCategories = listOf(
         "All" to "all",
@@ -162,13 +166,11 @@ class  WtrLabProvider : MainAPI() {
 
     override suspend fun load(url: String): LoadResponse {
         val doc = app.get(url).document
-        val title =
-            doc.selectFirst("h1")?.text()
-                ?: throw ErrorLoadingException("No title")
+        val title = doc.selectFirst("h1")?.text() ?: throw ErrorLoadingException("No title")
         val jsonNode = doc.selectFirst("#__NEXT_DATA__")
         val json = jsonNode?.data() ?: throw ErrorLoadingException("no chapters")
         val chaptersJson = parseJson<ResultJsonResponse.Root>(json)
-
+        novelId = chaptersJson.props.pageProps.serie.serieData.id.toString()
 
         val chapters = mutableListOf<ChapterData>()
         chapters.addAll(
@@ -201,9 +203,49 @@ class  WtrLabProvider : MainAPI() {
                     it.times(20).times(10).roundToInt()
                 }
             }
+            related = getRelated()
         }
     }
+    suspend fun getRelated(): List<SearchResponse> {
+        if (novelId.isEmpty()) return emptyList()
 
+        val url = "$mainUrl/api/v2/novel/similar/$novelId"
+        val response = app.get(url).parsedSafe<RelatedResponse>()
+
+        return response?.data?.mapNotNull { item ->
+            val title = item.data?.title ?: return@mapNotNull null
+            val slug = item.slug ?: return@mapNotNull null
+
+            val href = "$mainUrl/en/novel/$slug"
+
+            newSearchResponse(
+                name = title,
+                url = href
+            ) {
+                posterUrl = fixUrlNull(item.data.image)
+            }
+        } ?: emptyList()
+    }
+    override suspend fun loadReviews(
+        url: String,
+        page: Int,
+        showSpoilers: Boolean
+    ): List<UserReview> {
+        if (novelId.isEmpty()) return emptyList()
+
+        val realUrl = "$mainUrl/api/review/get?serie_id=$novelId&page=${page - 1}&sort=most_liked"
+        val res = app.get(realUrl).parsedSafe<ReviewResponse>()
+
+        return res?.data?.mapNotNull { item ->
+            val reviewTxt = item.comment ?: return@mapNotNull null
+            UserReview(
+                review = reviewTxt,
+                username = item.username ?: "User",
+                reviewDate = item.createdAt,
+                rating = item.rate?.times(200)
+            )
+        } ?: emptyList()
+    }
 
     override suspend fun loadHtml(url: String): String {
         val doc = app.get(url).document
@@ -278,6 +320,32 @@ class  WtrLabProvider : MainAPI() {
         }
     }
 
+    data class RelatedResponse(
+        @JsonProperty("success") val success: Boolean? = null,
+        @JsonProperty("data") val data: List<RelatedItem>? = null
+    )
+
+    data class RelatedItem(
+        @JsonProperty("slug") val slug: String? = null,
+        @JsonProperty("data") val data: RelatedInnerData? = null
+    )
+
+    data class RelatedInnerData(
+        @JsonProperty("title") val title: String? = null,
+        @JsonProperty("image") val image: String? = null
+    )
+    data class ReviewResponse(
+        @JsonProperty("success") val success: Boolean? = null,
+        @JsonProperty("data") val data: List<ReviewItem>? = null
+    )
+
+    data class ReviewItem(
+        @JsonProperty("comment") val comment: String? = null,
+        @JsonProperty("rate") val rate: Int? = null,
+        @JsonProperty("username") val username: String? = null,
+        @JsonProperty("created_at") val createdAt: String? = null,
+        @JsonProperty("user_id") val userId: String? = null
+    )
 
     object ResultChaptersJsonResponse {
         data class Root(
@@ -349,8 +417,9 @@ class  WtrLabProvider : MainAPI() {
         data class SerieData(
             @JsonProperty("raw_id")
             val rawId: Long,
+            @JsonProperty("id")
+            val id: Long,
             /*
-            val id: Long,val slug: String,
             @JsonProperty("search_text")
             val searchText: String,
             val status: Long,

--- a/app/src/main/java/com/lagradost/quicknovel/providers/WtrLabProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/WtrLabProvider.kt
@@ -153,7 +153,6 @@ class  WtrLabProvider : MainAPI() {
         val chaptersDataJson =
             app.get(chapterDataUrl).text
         val chaptersData = parseJson<ResultChaptersJsonResponse.Root>(chaptersDataJson)
-
         return chaptersData.chapters.map { chapter ->
             newChapterData(
                 "#${chapter.order} ${chapter.title}",
@@ -212,17 +211,18 @@ class  WtrLabProvider : MainAPI() {
         val url = "$mainUrl/api/v2/novel/similar/$novelId"
         val response = app.get(url).parsedSafe<RelatedResponse>()
 
-        return response?.data?.mapNotNull { item ->
-            val title = item.data?.title ?: return@mapNotNull null
-            val slug = item.slug ?: return@mapNotNull null
+        return response?.data?.map { item ->
+            val title = item.innerData.title
+            val id = item.id
+            val slug = item.slug
 
-            val href = "$mainUrl/en/novel/$slug"
+            val href = "$mainUrl/en/novel/$id/$slug"
 
             newSearchResponse(
                 name = title,
                 url = href
             ) {
-                posterUrl = fixUrlNull(item.data.image)
+                posterUrl = fixUrlNull(item.innerData.image)
             }
         } ?: emptyList()
     }
@@ -235,7 +235,6 @@ class  WtrLabProvider : MainAPI() {
 
         val realUrl = "$mainUrl/api/review/get?serie_id=$novelId&page=${page - 1}&sort=most_liked"
         val res = app.get(realUrl).parsedSafe<ReviewResponse>()
-
         return res?.data?.mapNotNull { item ->
             val reviewTxt = item.comment ?: return@mapNotNull null
             UserReview(
@@ -321,18 +320,19 @@ class  WtrLabProvider : MainAPI() {
     }
 
     data class RelatedResponse(
-        @JsonProperty("success") val success: Boolean? = null,
+        @JsonProperty("success") val success: Boolean,
         @JsonProperty("data") val data: List<RelatedItem>? = null
     )
 
     data class RelatedItem(
-        @JsonProperty("slug") val slug: String? = null,
-        @JsonProperty("data") val data: RelatedInnerData? = null
+        @JsonProperty("raw_id") val id: Long,
+        @JsonProperty("slug") val slug: String,
+        @JsonProperty("data") val innerData: RelatedInnerData,
     )
 
     data class RelatedInnerData(
-        @JsonProperty("title") val title: String? = null,
-        @JsonProperty("image") val image: String? = null
+        @JsonProperty("title") val title: String,
+        @JsonProperty("image") val image: String? = null,
     )
     data class ReviewResponse(
         @JsonProperty("success") val success: Boolean? = null,

--- a/app/src/main/java/com/lagradost/quicknovel/providers/WtrLabProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/WtrLabProvider.kt
@@ -19,6 +19,7 @@ import com.lagradost.quicknovel.providers.NovelFireProvider.RelatedResponse
 import com.lagradost.quicknovel.setStatus
 import com.lagradost.quicknovel.util.AppUtils.parseJson
 import org.jsoup.Jsoup
+import java.util.concurrent.ConcurrentHashMap
 import javax.crypto.Cipher
 import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.SecretKeySpec
@@ -33,8 +34,8 @@ class  WtrLabProvider : MainAPI() {
     override val hasMainPage = true
     override val usesCloudFlareKiller = true
     override val hasReviews = true
-    var novelId = ""
-    //&status=
+    val novelsIdRequired = ConcurrentHashMap<String, String>()
+
     override val mainCategories = listOf(
         "All" to "all",
         "Ongoing" to "ongoing",
@@ -169,7 +170,7 @@ class  WtrLabProvider : MainAPI() {
         val jsonNode = doc.selectFirst("#__NEXT_DATA__")
         val json = jsonNode?.data() ?: throw ErrorLoadingException("no chapters")
         val chaptersJson = parseJson<ResultJsonResponse.Root>(json)
-        novelId = chaptersJson.props.pageProps.serie.serieData.id.toString()
+        novelsIdRequired[url] = chaptersJson.props.pageProps.serie.serieData.id.toString()
 
         val chapters = mutableListOf<ChapterData>()
         chapters.addAll(
@@ -202,13 +203,11 @@ class  WtrLabProvider : MainAPI() {
                     it.times(20).times(10).roundToInt()
                 }
             }
-            related = getRelated()
+            related = getRelated(url)
         }
     }
-    suspend fun getRelated(): List<SearchResponse> {
-        if (novelId.isEmpty()) return emptyList()
-
-        val url = "$mainUrl/api/v2/novel/similar/$novelId"
+    suspend fun getRelated(url: String): List<SearchResponse> {
+        val url = "$mainUrl/api/v2/novel/similar/${novelsIdRequired[url]}"
         val response = app.get(url).parsedSafe<RelatedResponse>()
 
         return response?.data?.map { item ->
@@ -231,9 +230,7 @@ class  WtrLabProvider : MainAPI() {
         page: Int,
         showSpoilers: Boolean
     ): List<UserReview> {
-        if (novelId.isEmpty()) return emptyList()
-
-        val realUrl = "$mainUrl/api/review/get?serie_id=$novelId&page=${page - 1}&sort=most_liked"
+        val realUrl = "$mainUrl/api/review/get?serie_id=${novelsIdRequired[url]}&page=${page - 1}&sort=most_liked"
         val res = app.get(realUrl).parsedSafe<ReviewResponse>()
         return res?.data?.mapNotNull { item ->
             val reviewTxt = item.comment ?: return@mapNotNull null

--- a/app/src/main/java/com/lagradost/quicknovel/providers/WuxiaBoxProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/WuxiaBoxProvider.kt
@@ -1,12 +1,10 @@
 package com.lagradost.quicknovel.providers
 
-import android.R.attr.tag
-import android.util.Log
+
 import com.lagradost.quicknovel.ChapterData
 import com.lagradost.quicknovel.HeadMainPageResponse
 import com.lagradost.quicknovel.LoadResponse
 import com.lagradost.quicknovel.MainAPI
-import com.lagradost.quicknovel.MainActivity.Companion.app
 import com.lagradost.quicknovel.R
 import com.lagradost.quicknovel.SearchResponse
 import com.lagradost.quicknovel.fixUrl
@@ -15,7 +13,7 @@ import com.lagradost.quicknovel.newChapterData
 import com.lagradost.quicknovel.newSearchResponse
 import com.lagradost.quicknovel.newStreamResponse
 import com.lagradost.quicknovel.setStatus
-import kotlin.collections.isNotEmpty
+import org.jsoup.nodes.Document
 
 open class WuxiaBoxProvider : MainAPI() {
     override val name = "WuxiaBox"
@@ -122,6 +120,21 @@ open class WuxiaBoxProvider : MainAPI() {
         return HeadMainPageResponse(url, returnValue)
     }
 
+    private fun getRelated(document: Document): List<SearchResponse> {
+        return document.select("div.section-body > ul.novel-list > li").mapNotNull { element ->
+            val href = element.selectFirst("a")?.attr("href") ?: return@mapNotNull null
+            val title = element.selectFirst("h5")?.text() ?: return@mapNotNull null
+            newSearchResponse(
+                name = title,
+                url = href
+            ) {
+                posterUrl = fixUrlNull(
+                    element.selectFirst("img")?.attr("data-src")
+                )
+            }
+        }
+    }
+
     override suspend fun load(url: String): LoadResponse?
     {
         val document = app.get(url).document
@@ -172,6 +185,7 @@ open class WuxiaBoxProvider : MainAPI() {
             this.posterUrl = fixUrlNull(cover)
             this.synopsis = synopsis
             setStatus(status)
+            related = getRelated(document)
         }
     }
 

--- a/app/src/main/java/com/lagradost/quicknovel/providers/WuxiaClickProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/WuxiaClickProvider.kt
@@ -17,6 +17,7 @@ import com.lagradost.quicknovel.newStreamResponse
 import com.lagradost.quicknovel.providers.WtrLabProvider.ReviewResponse
 import com.lagradost.quicknovel.setStatus
 import org.jsoup.nodes.Element
+import java.util.concurrent.ConcurrentHashMap
 
 class WuxiaClickProvider :  MainAPI() {
     override val name = "WuxiaClick"
@@ -25,7 +26,7 @@ class WuxiaClickProvider :  MainAPI() {
     override val iconId = R.drawable.icon_wuxiaclick
     override val iconBackgroundId = R.color.wuxiacliColor
     override val hasReviews = true
-    var novelId = ""
+    val novelsIdRequired = ConcurrentHashMap<String, String>()
 
 
     override val hasMainPage = true
@@ -303,7 +304,7 @@ class WuxiaClickProvider :  MainAPI() {
         val infoDiv = document.selectFirst("div.mantine-Container-root > div.mantine-Paper-root.mantine-Card-root > div")
         val title = infoDiv?.selectFirst("h5")?.text() ?: throw Exception("Title not found")
         val chapters = getChapters(infoDiv, url)
-        novelId = url.removeSuffix("/").substringAfterLast("/")
+        novelsIdRequired[url] = url.removeSuffix("/").substringAfterLast("/")
         return newStreamResponse(title,fixUrl(url), chapters) {
             this.posterUrl = infoDiv.selectFirst("img")?.attr("src")
             this.synopsis = infoDiv.selectFirst("div.mantine-Spoiler-root > div.mantine-Spoiler-content > div > div.mantine-Text-root")?.text() ?: ""
@@ -312,17 +313,16 @@ class WuxiaClickProvider :  MainAPI() {
 
             setStatus(infoDiv.selectFirst("div.mantine-Group-root.mantine-1uxmzbt > div.mantine-1huvzos")?.text())
 
-            this.tags = infoDiv.select("div.mantine-Spoiler-root > div.mantine-Spoiler-content > div > div.mantine-Group-root > div")?.mapNotNull {
+            this.tags = infoDiv.select("div.mantine-Spoiler-root > div.mantine-Spoiler-content > div > div.mantine-Group-root > div").mapNotNull {
                 it.text().trim().takeIf { text ->  !text.isEmpty() }
             }
-            related = getRelated()
+            related = getRelated(url)
         }
     }
 
-    suspend fun getRelated(): List<SearchResponse> {
-        val url = "$secondUrl/api/novels/$novelId/recommendations/"
+    suspend fun getRelated(url: String): List<SearchResponse> {
+        val url = "$secondUrl/api/novels/${novelsIdRequired[url]}/recommendations/"
         val response = app.get(url).parsed<RelatedResponse>()
-        println(response)
         return response.results.map { item ->
             val title = item.name
             val slug = item.slug
@@ -344,7 +344,7 @@ class WuxiaClickProvider :  MainAPI() {
         showSpoilers: Boolean
     ): List<UserReview> {
 
-        val realUrl = "$secondUrl/api/review/?novel_id=$novelId&page=$page&itemsPerPage=10"
+        val realUrl = "$secondUrl/api/review/?novel_id=${novelsIdRequired[url]}&page=$page&itemsPerPage=10"
         val res = app.get(realUrl).parsedSafe<WuxiaWorldReviewResponse>()
 
         return res?.results?.mapNotNull { item ->

--- a/app/src/main/java/com/lagradost/quicknovel/providers/WuxiaClickProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/WuxiaClickProvider.kt
@@ -1,25 +1,31 @@
 package com.lagradost.quicknovel.providers
 
 import android.net.Uri
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.quicknovel.ChapterData
 import com.lagradost.quicknovel.HeadMainPageResponse
 import com.lagradost.quicknovel.LoadResponse
 import com.lagradost.quicknovel.MainAPI
-import com.lagradost.quicknovel.MainActivity.Companion.app
 import com.lagradost.quicknovel.R
 import com.lagradost.quicknovel.SearchResponse
+import com.lagradost.quicknovel.UserReview
 import com.lagradost.quicknovel.fixUrl
+import com.lagradost.quicknovel.fixUrlNull
 import com.lagradost.quicknovel.newChapterData
 import com.lagradost.quicknovel.newSearchResponse
 import com.lagradost.quicknovel.newStreamResponse
+import com.lagradost.quicknovel.providers.WtrLabProvider.ReviewResponse
 import com.lagradost.quicknovel.setStatus
 import org.jsoup.nodes.Element
 
 class WuxiaClickProvider :  MainAPI() {
     override val name = "WuxiaClick"
     override val mainUrl = "https://wuxia.click"
+    val secondUrl = "https://wuxiaworld.eu"
     override val iconId = R.drawable.icon_wuxiaclick
     override val iconBackgroundId = R.color.wuxiacliColor
+    override val hasReviews = true
+    var novelId = ""
 
 
     override val hasMainPage = true
@@ -297,7 +303,7 @@ class WuxiaClickProvider :  MainAPI() {
         val infoDiv = document.selectFirst("div.mantine-Container-root > div.mantine-Paper-root.mantine-Card-root > div")
         val title = infoDiv?.selectFirst("h5")?.text() ?: throw Exception("Title not found")
         val chapters = getChapters(infoDiv, url)
-
+        novelId = url.removeSuffix("/").substringAfterLast("/")
         return newStreamResponse(title,fixUrl(url), chapters) {
             this.posterUrl = infoDiv.selectFirst("img")?.attr("src")
             this.synopsis = infoDiv.selectFirst("div.mantine-Spoiler-root > div.mantine-Spoiler-content > div > div.mantine-Text-root")?.text() ?: ""
@@ -309,9 +315,54 @@ class WuxiaClickProvider :  MainAPI() {
             this.tags = infoDiv.select("div.mantine-Spoiler-root > div.mantine-Spoiler-content > div > div.mantine-Group-root > div")?.mapNotNull {
                 it.text().trim().takeIf { text ->  !text.isEmpty() }
             }
+            related = getRelated()
         }
     }
 
+    suspend fun getRelated(): List<SearchResponse> {
+        val url = "$secondUrl/api/novels/$novelId/recommendations/"
+        val response = app.get(url).parsed<RelatedResponse>()
+        println(response)
+        return response.results.map { item ->
+            val title = item.name
+            val slug = item.slug
+
+            val href = "$mainUrl/novel/$slug"
+
+            newSearchResponse(
+                name = title,
+                url = href
+            ) {
+                posterUrl = fixUrlNull(item.image)
+            }
+        } ?: emptyList()
+    }
+
+    override suspend fun loadReviews(
+        url: String,
+        page: Int,
+        showSpoilers: Boolean
+    ): List<UserReview> {
+
+        val realUrl = "$secondUrl/api/review/?novel_id=$novelId&page=$page&itemsPerPage=10"
+        val res = app.get(realUrl).parsedSafe<WuxiaWorldReviewResponse>()
+
+        return res?.results?.mapNotNull { item ->
+            if (item.spoiler == true && !showSpoilers) return@mapNotNull null
+
+            val reviewTxt = item.description ?: return@mapNotNull null
+
+            val cleanDate = item.createdAt?.replace("T", " ")
+
+            UserReview(
+                review = reviewTxt,
+                username = item.ownerUser?.user?.username ?: "User",
+                reviewDate = cleanDate,
+                avatarUrl = fixUrlNull(item.ownerUser?.imageUrl),
+                rating = item.totalScore?.times(200),
+            )
+        } ?: emptyList()
+    }
 
     override suspend fun loadHtml(url: String): String {
         val document = app.get(url).document
@@ -335,4 +386,39 @@ class WuxiaClickProvider :  MainAPI() {
 
             }
     }
+
+    data class RelatedResponse(
+        @JsonProperty("results")
+        val results:List<Related>
+    )
+    data class Related(
+        @JsonProperty("name")
+        val name: String,
+        @JsonProperty("image")
+        val image: String?,
+        @JsonProperty("slug")
+        val slug: String
+    )
+
+    data class WuxiaWorldReviewResponse(
+        @JsonProperty("results") val results: List<WuxiaWorldReviewItem>? = null,
+        @JsonProperty("count") val count: Int? = null
+    )
+
+    data class WuxiaWorldReviewItem(
+        @JsonProperty("description") val description: String? = null,
+        @JsonProperty("total_score") val totalScore: Int? = null,
+        @JsonProperty("created_at") val createdAt: String? = null,
+        @JsonProperty("owner_user") val ownerUser: WuxiaWorldOwner? = null,
+        @JsonProperty("spoiler") val spoiler: Boolean? = null
+    )
+
+    data class WuxiaWorldOwner(
+        @JsonProperty("user") val user: WuxiaWorldUserDetail? = null,
+        @JsonProperty("imageUrl") val imageUrl: String? = null
+    )
+
+    data class WuxiaWorldUserDetail(
+        @JsonProperty("username") val username: String? = null
+    )
 }

--- a/app/src/main/java/com/lagradost/quicknovel/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/ui/settings/SettingsFragment.kt
@@ -110,7 +110,6 @@ class SettingsFragment : Fragment(), SearchableSettings by SettingScreen() {
             return when {
                 path.isNullOrBlank() -> getDefaultDir(context)
                 path.startsWith("content://") -> SafeFile.fromUri(context, path.toUri())
-                path.startsWith("/storage") -> SafeFile.fromFilePath(context, path)
                 else -> SafeFile.fromFilePath(
                     context,
                     path.removePrefix(Environment.getExternalStorageDirectory().path).removePrefix(

--- a/app/src/main/java/com/lagradost/quicknovel/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/ui/settings/SettingsFragment.kt
@@ -110,6 +110,7 @@ class SettingsFragment : Fragment(), SearchableSettings by SettingScreen() {
             return when {
                 path.isNullOrBlank() -> getDefaultDir(context)
                 path.startsWith("content://") -> SafeFile.fromUri(context, path.toUri())
+                path.startsWith("/storage") -> SafeFile.fromFilePath(context, path)
                 else -> SafeFile.fromFilePath(
                     context,
                     path.removePrefix(Environment.getExternalStorageDirectory().path).removePrefix(

--- a/app/src/main/java/com/lagradost/quicknovel/util/Apis.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/util/Apis.kt
@@ -104,7 +104,7 @@ class Apis {
             NovelLightProvider(),
             NovelManiaProvider(),
             //NovelPassionProvider(), // Site gone
-            NovelsOnlineProvider(),
+            //NovelsOnlineProvider(), // not working
             NovLoveProvider(),
             NovelPhoenixProvider(),
             PawReadProver(),


### PR DESCRIPTION
I made some general fixes to some providers (I'll keep updating this PR since there's still more to do).

For now, there are two main highlights:

1. I fixed out-of-memory issues when reading very large EPUBs.
2. I had to do something pretty crazy for Anna's Archive. They fixed the issue where their EPUB URLs were easily accessible, so the only option left was to work around their anti-bot protections. They're either really good at what they do, or I'm really bad haha. I tried updating the Cloudflare Killer and WebView logic, but no matter how much I researched, I couldn't get it working. As a last resort, I implemented a new approach that uses WebView directly for Anna's Archive. It works extremely well, and it could eventually be used for other equally difficult providers like JNovels, but that's something for the future. The important thing is that Anna's Archive keeps working, because it's simply too good of a provider to lose.
