### PR TITLE
Fix 0/0 download progress on certain FreeWebNovel novels

### DIFF
--- a/app/src/main/java/com/lagradost/quicknovel/providers/LibReadProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/LibReadProvider.kt
@@ -9,7 +9,7 @@ open class LibReadProvider : MainAPI() {
     override val mainUrl = "https://libread.com"
 
     //for some reason, now is freewebnovel
-    val secondUrl = "https://freewebnovel.com"
+    val secondUrl = "http://10.0.2.2:8080"
     override val hasMainPage = true
 
     open val removeHtml = false // because the two sites use .html or not for no reason
@@ -65,19 +65,34 @@ open class LibReadProvider : MainAPI() {
     )
 
     private fun getChapterList(doc: Document, url: String): List<ChapterData> {
+        // Template A (JS-paginated): the chapter count lives in a
+        // `window.chapterPagination` script block. Construct chapter URLs from
+        // the slug + index.
         val scriptData = doc.select("script").map { it.data() }
-            .find { it.contains("window.chapterPagination") } ?: return emptyList()
+            .find { it.contains("window.chapterPagination") }
+        if (scriptData != null) {
+            val totalChapters = "totalChapters:\\s*(\\d+)".toRegex()
+                .find(scriptData)?.groupValues?.get(1)?.toIntOrNull() ?: 0
+            val cleanedUrl = url.removeSuffix("/").substringAfterLast("/")
+                .replace("(-novel)?-\\d{4,}+$".toRegex(), "")
+            return (1..totalChapters).map { i ->
+                newChapterData(
+                    name = "Chapter $i",
+                    url = "$secondUrl/novel/$cleanedUrl/chapter-$i"
+                )
+            }
+        }
 
-        val totalChapters = "totalChapters:\\s*(\\d+)".toRegex()
-            .find(scriptData)?.groupValues?.get(1)?.toIntOrNull() ?: 0
-
-        val cleanedUrl = url.removeSuffix("/").substringAfterLast("/").replace("(-novel)?-\\d{4,}+$".toRegex(), "")
-
-        return (1..totalChapters).map { i ->
-            newChapterData(
-                name = "Chapter $i",
-                url = "$secondUrl/novel/$cleanedUrl/chapter-$i"
-            )
+        // Template B (legacy all-chapters-on-page): no pagination script is
+        // present, so fall back to scraping the chapter <li> elements directly.
+        // This is the pre-#459 behaviour and is still required for a large
+        // subset of FreeWebNovel novel pages (e.g. `a-practical-guide-to-evil`).
+        // Without this fallback, load() returns a StreamResponse with 0
+        // chapters, which overwrites DOWNLOAD_TOTAL with 0 and surfaces to the
+        // user as a permanent "0/0" download row (issue #481).
+        return doc.select("div.m-newest2 ul.ul-list5 li").mapNotNull { c ->
+            val a = c.selectFirst("a") ?: return@mapNotNull null
+            newChapterData(url = a.attr("href"), name = a.text())
         }
     }
     override suspend fun loadMainPage(


### PR DESCRIPTION
## Summary
- Restores DOM-based chapter extraction as a fallback for FreeWebNovel pages that lack `window.chapterPagination`
- Fixes issue #481 where certain novels showed permanent "0/0" download progress
- Pages with `window.chapterPagination` are unaffected

## Root cause
PR #459 changed chapter list extraction from DOM-based scraping to script-based parsing (`window.chapterPagination`). However, many FreeWebNovel novel pages don't contain this script — they list all chapters directly in the DOM under `div.m-newest2 ul.ul-list5 li`. For those pages, `getChapterList()` returned 0 chapters, which overwrote `DOWNLOAD_TOTAL` with 0.

## Fix
Restores the pre-#459 DOM-based extraction as a fallback when `window.chapterPagination` is absent.
<img width="448" height="994" alt="screenshot-2026-07-18_20-00-21" src="https://github.com/user-attachments/assets/538e0878-8a21-4317-a048-93ea07f944ce" />