### PR TITLE
Add click-to-copy and long-press-to-search on novel titles

### DIFF
--- a/app/src/main/java/com/lagradost/quicknovel/ui/result/ResultFragment.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/ui/result/ResultFragment.kt
@@ -40,6 +40,7 @@ import com.lagradost.quicknovel.ui.ReadType
 import com.lagradost.quicknovel.ui.SortingMethodAdapter
 import com.lagradost.quicknovel.ui.mainpage.MainAdapter
 import com.lagradost.quicknovel.ui.mainpage.MainPageFragment
+import com.lagradost.quicknovel.ui.search.SearchFragmentExtras
 import com.lagradost.quicknovel.ui.setRecycledViewPool
 import com.lagradost.quicknovel.util.SettingsHelper.getRating
 import com.lagradost.quicknovel.util.SingleSelectionHelper.showBottomDialog
@@ -180,6 +181,28 @@ class ResultFragment : BaseFragment<FragmentResultBinding>(
 
                     resultTitle.text = res.name
                     resultAuthor.text = res.author ?: getString(R.string.no_author)
+
+                    // Click title to copy to clipboard, long-press to search across providers
+                    resultTitle.setOnClickListener {
+                        val ctx = it.context
+                        val clipboard = ctx.getSystemService(android.content.Context.CLIPBOARD_SERVICE)
+                            as android.content.ClipboardManager
+                        clipboard.setPrimaryClip(android.content.ClipData.newPlainText("novel_title", res.name))
+                        android.widget.Toast.makeText(ctx, ctx.getString(R.string.toast_copied), android.widget.Toast.LENGTH_SHORT).show()
+                    }
+                    resultTitle.setOnLongClickListener {
+                        val act = activity as? androidx.fragment.app.FragmentActivity ?: return@setOnLongClickListener true
+                        SearchFragmentExtras.pendingSearchQuery = res.name
+                        val navHostFragment = act.supportFragmentManager
+                            .findFragmentById(com.lagradost.quicknovel.R.id.nav_host_fragment) as? androidx.navigation.fragment.NavHostFragment
+                        val navController = navHostFragment?.navController ?: return@setOnLongClickListener true
+                        val navOptions = androidx.navigation.NavOptions.Builder()
+                            .setLaunchSingleTop(true)
+                            .setPopUpTo(navController.graph.startDestinationId, false)
+                            .build()
+                        navController.navigate(com.lagradost.quicknovel.R.id.navigation_search, null, navOptions)
+                        true
+                    }
 
                     resultRatingVotedCount.text = getString(R.string.no_data)
                     res.rating?.let { rating ->

--- a/app/src/main/java/com/lagradost/quicknovel/ui/search/SearchFragment.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/ui/search/SearchFragment.kt
@@ -27,6 +27,11 @@ import com.lagradost.quicknovel.ui.settings.searchProvidersList
 import kotlinx.collections.immutable.toPersistentSet
 
 
+object SearchFragmentExtras {
+    @JvmStatic
+    var pendingSearchQuery: String? = null
+}
+
 class SearchFragment : Fragment() {
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -44,6 +49,9 @@ class SearchFragment : Fragment() {
                 //val viewModel: HomeViewModel2 =
                //     viewModel(factory = HomeViewModel2.provideFactory(store.searchProvidersList()))
                 val state by viewModel.state.collectAsStateWithLifecycle()
+
+                // Auto-search if a query was passed (e.g. from novel title long-press)
+                val pendingQuery = SearchFragmentExtras.pendingSearchQuery
 
                 val store = AndroidPreferenceStore(context)
                 val selectionState by store.searchProvidersList().collectAsState()
@@ -68,7 +76,7 @@ class SearchFragment : Fragment() {
                     }
                 }
 
-                SearchScreen(state, viewModel::onAction)
+                SearchScreen(state, viewModel::onAction, pendingQuery)
             }
         }
     }

--- a/app/src/main/java/com/lagradost/quicknovel/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/ui/search/SearchScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -66,7 +68,7 @@ import kotlinx.collections.immutable.toPersistentSet
 import kotlin.uuid.ExperimentalUuidApi
 
 @Composable
-fun SearchScreen(state: HomeViewModelState, action: (HomeAction) -> Unit) {
+fun SearchScreen(state: HomeViewModelState, action: (HomeAction) -> Unit, pendingQuery: String? = null) {
     ShowDialog(state.filterLanguages, state.isConfigureShow, action)
     BackHandler(state.isQueryOpen) {
         action(HomeAction.CloseQuery)
@@ -74,6 +76,14 @@ fun SearchScreen(state: HomeViewModelState, action: (HomeAction) -> Unit) {
 
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(snapAnimationSpec = null)
     val listState = rememberLazyGridState()
+    val textFieldState = rememberTextFieldState()
+
+    LaunchedEffect(pendingQuery) {
+        if (!pendingQuery.isNullOrBlank()) {
+            textFieldState.edit { replace(0, length, pendingQuery) }
+            action(HomeAction.Search(pendingQuery))
+        }
+    }
 
     val openAction = remember<(ImmutableSearchResponse) -> Unit>(action) {
         { item ->
@@ -106,6 +116,7 @@ fun SearchScreen(state: HomeViewModelState, action: (HomeAction) -> Unit) {
                 onSearch = { query ->
                     action(HomeAction.Search(query))
                 },
+                textFieldState = textFieldState,
                 trailingIcon = {
                     if (state.isLoading && state.isQueryOpen) {
                         CircularProgressIndicator(

--- a/app/src/main/res/layout/fragment_result.xml
+++ b/app/src/main/res/layout/fragment_result.xml
@@ -228,80 +228,6 @@
         android:visibility="gone"
         tools:visibility="visible">
 
-        <LinearLayout
-            android:id="@+id/result_info_header"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="10dp"
-            android:orientation="horizontal">
-
-            <androidx.cardview.widget.CardView
-                android:layout_width="100dp"
-                android:layout_height="150dp"
-                android:elevation="10dp"
-                app:cardCornerRadius="@dimen/roundedImageRadius">
-
-                <ImageView
-                    android:id="@+id/result_poster"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:clickable="true"
-                    android:contentDescription="@string/novel_imagecover_descript"
-                    android:focusable="true"
-                    android:foreground="?android:attr/selectableItemBackgroundBorderless"
-                    android:scaleType="centerCrop" />
-            </androidx.cardview.widget.CardView>
-
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:layout_marginLeft="10dp"
-                android:orientation="vertical">
-
-                <TextView
-                    android:id="@+id/result_title"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="40dp"
-                    android:ellipsize="end"
-                    android:maxLines="2"
-                    android:text="@string/no_data"
-                    android:textColor="?attr/textColor"
-                    android:textSize="20sp"
-                    tools:text="The Beginning After The End The Beginning After The End" />
-
-                <TextView
-                    android:id="@+id/result_author"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="10dp"
-                    android:text="@string/no_data"
-                    android:textColor="?attr/colorAccent"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:id="@+id/result_status"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="10dp"
-                    android:text="@string/no_data"
-                    android:textColor="?attr/textColor"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:id="@+id/result_total_chapters"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="10dp"
-                    android:text="@string/no_data"
-                    android:textColor="?attr/textColor"
-                    android:textSize="14sp"
-                    android:visibility="visible" />
-            </LinearLayout>
-        </LinearLayout>
-
         <androidx.core.widget.NestedScrollView
             android:id="@+id/result_mainscroll"
             android:layout_width="match_parent"
@@ -796,6 +722,84 @@ Translator: Rainbow Turtle" />
                 </FrameLayout>
             </LinearLayout>
         </androidx.core.widget.NestedScrollView>
+
+        <LinearLayout
+            android:id="@+id/result_info_header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:fitsSystemWindows="true"
+            android:orientation="horizontal">
+
+            <androidx.cardview.widget.CardView
+                android:layout_width="100dp"
+                android:layout_height="150dp"
+                android:elevation="10dp"
+                app:cardCornerRadius="@dimen/roundedImageRadius">
+
+                <ImageView
+                    android:id="@+id/result_poster"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:clickable="true"
+                    android:contentDescription="@string/novel_imagecover_descript"
+                    android:focusable="true"
+                    android:foreground="?android:attr/selectableItemBackgroundBorderless"
+                    android:scaleType="centerCrop" />
+            </androidx.cardview.widget.CardView>
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_marginLeft="10dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/result_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="40dp"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:longClickable="true"
+                    android:ellipsize="end"
+                    android:maxLines="2"
+                    android:text="@string/no_data"
+                    android:textColor="?attr/textColor"
+                    android:textSize="20sp"
+                    tools:text="The Beginning After The End The Beginning After The End" />
+
+                <TextView
+                    android:id="@+id/result_author"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:text="@string/no_data"
+                    android:textColor="?attr/colorAccent"
+                    android:textSize="14sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/result_status"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:text="@string/no_data"
+                    android:textColor="?attr/textColor"
+                    android:textSize="14sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/result_total_chapters"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:text="@string/no_data"
+                    android:textColor="?attr/textColor"
+                    android:textSize="14sp"
+                    android:visibility="visible" />
+            </LinearLayout>
+        </LinearLayout>
     </FrameLayout>
 
     <ImageView


### PR DESCRIPTION
## Summary
- **Click novel title** → copies the title to clipboard with a "copied!" toast
- **Long-press novel title** → navigates to the search page, auto-fills the search bar with the title, and searches across all enabled providers

Related issue: #462

### Changes
| File | Change |
|------|--------|
| `ResultFragment.kt` | Added `setOnClickListener` (copy) and `setOnLongClickListener` (search) on `resultTitle` |
| `SearchFragment.kt` | Added `SearchFragmentExtras` static variable to pass query between fragments |
| `SearchScreen.kt` | Added `pendingQuery` parameter + `LaunchedEffect` to auto-fill search bar and trigger search |
| `fragment_result.xml` | Moved `result_info_header` after `NestedScrollView` so title receives touches (was intercepted by ScrollView z-order). Added `fitsSystemWindows` to keep title below status bar. Added `longClickable="true"` on title. |

### Why the layout change?
In a `FrameLayout`, later children draw on top. The `NestedScrollView` was the second child, covering the header and swallowing all touch events. Moving the header after the ScrollView ensures it receives clicks and long-presses.

https://github.com/user-attachments/assets/c4f01fce-bce8-49e5-9da0-3d3eb8f10708