### PR TITLE
Add minimal issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,38 @@
+name: Bug report
+description: Something is broken
+labels: [bug]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What went wrong, and what did you expect instead? Steps to reproduce if you know them.
+    validations:
+      required: true
+  - type: input
+    id: app-version
+    attributes:
+      label: QuickNovel version
+      placeholder: e.g. 3.6.1
+    validations:
+      required: false
+  - type: input
+    id: android-version
+    attributes:
+      label: Android version
+      placeholder: e.g. Android 15
+    validations:
+      required: false
+  - type: input
+    id: provider
+    attributes:
+      label: Source/provider (if provider-related)
+      placeholder: e.g. WTR-LAB
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots (optional)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,11 @@
+name: Feature request
+description: Suggest an idea or a new source
+labels: [enhancement]
+body:
+  - type: textarea
+    id: idea
+    attributes:
+      label: What would you like?
+      description: Describe the feature, or paste the link of the source you want added.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+<!-- All items optional - delete anything that does not apply. -->
+
+Closes #
+
+- [ ] Referenced related issues (e.g. "Closes #xyz")
+- [ ] No source names changed unless necessary
+- [ ] No dependencies added/removed/changed unless necessary
+- [ ] Tested by compiling and running through Android Studio


### PR DESCRIPTION
Closes #210

Adds minimal, deliberately non-restrictive templates, keeping in mind the concern about over-restrictive guides making it harder to contribute:

- **Bug report form**: one required field ("What happened?"), everything else optional (app version, Android version, provider, logs)
- **Feature request form**: single field, also covers source requests
- **Blank issues stay enabled** (`config.yml`) — nobody is forced through the forms
- **PR template**: the 4-point checklist from #210, marked optional

Net effect: issues arrive with version/provider info more often (most "bug" reports currently lack them), at zero cost to anyone who prefers free-form.
