### PR TITLE
Fix background downloads not working

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,6 +48,12 @@
             android:exported="false"
             android:foregroundServiceType="dataSync" />
 
+        <!-- Android 14+ rejects startForeground with a type that is not declared here -->
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            tools:node="merge" />
+
         <receiver
             android:name="androidx.media.session.MediaButtonReceiver"
             android:exported="true">

--- a/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
@@ -361,7 +361,7 @@ object BookDownloader2Helper {
     }
 
     fun copyAllData(
-        activity: Activity?,
+        context: Context?,
         fromAuthor: String?,
         fromName: String,
         fromApiName: String,
@@ -369,7 +369,7 @@ object BookDownloader2Helper {
         toName: String,
         toApiName: String
     ) {
-        if (activity == null) return
+        if (context == null) return
         val sFromApiName = sanitizeFilename(fromApiName)
         val sFromAuthor = if (fromAuthor == null) "" else sanitizeFilename(fromAuthor)
         val sFromName = sanitizeFilename(fromName)
@@ -383,18 +383,18 @@ object BookDownloader2Helper {
 
         val fromDir =
             File(
-                activity.filesDir.toString() + getDirectory(sFromApiName, sFromAuthor, sFromName)
+                context.filesDir.toString() + getDirectory(sFromApiName, sFromAuthor, sFromName)
             )
         val toDir =
             File(
-                activity.filesDir.toString() + getDirectory(sToApiName, sToAuthor, sToName)
+                context.filesDir.toString() + getDirectory(sToApiName, sToAuthor, sToName)
             )
         toDir.mkdirs()
         fromDir.copyRecursively(toDir, overwrite = false)
     }
 
-    fun deleteNovel(activity: Activity?, author: String?, name: String, apiName: String) {
-        if (activity == null) return
+    fun deleteNovel(context: Context?, author: String?, name: String, apiName: String) {
+        if (context == null) return
         try {
             val sApiName = sanitizeFilename(apiName)
             val sAuthor = if (author == null) "" else sanitizeFilename(author)
@@ -403,7 +403,7 @@ object BookDownloader2Helper {
 
             val dir =
                 File(
-                    activity.filesDir.toString() + getDirectory(sApiName, sAuthor, sName)
+                    context.filesDir.toString() + getDirectory(sApiName, sAuthor, sName)
                 )
 
             removeKey(DOWNLOAD_SIZE, id.toString())
@@ -909,7 +909,7 @@ object NotificationHelper {
         }
     }
 
-    private fun Context.createNotificationChannel() {
+    fun Context.createNotificationChannel() {
         hasCreatedNotChanel = true
         // Create the NotificationChannel, but only on API 26+ because
         // the NotificationChannel class is new and not in the support library
@@ -925,6 +925,34 @@ object NotificationHelper {
                 this.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
             notificationManager.createNotificationChannel(channel)
         }
+    }
+
+    // The id is fixed so the foreground notification is replaced, not stacked, per worker
+    const val FOREGROUND_NOTIFICATION_ID = 6660
+
+    fun buildForegroundNotification(context: Context): android.app.Notification {
+        if (!hasCreatedNotChanel) {
+            context.createNotificationChannel()
+        }
+
+        val intent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+        val pendingIntent: PendingIntent = PendingIntent.getActivity(
+            context, 0, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_IMMUTABLE else 0)
+        )
+
+        return NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.rdload)
+            .setContentTitle(context.getString(R.string.app_name))
+            .setContentText(context.getString(R.string.download_in_progress))
+            .setOngoing(true)
+            .setSilent(true)
+            .setOnlyAlertOnce(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setContentIntent(pendingIntent)
+            .build()
     }
 
     fun etaToString(etaMs: Long?): String {
@@ -1137,7 +1165,7 @@ object BookDownloader2 {
 
     @WorkerThread
     suspend fun stream(res: EpubResponse, apiName: String) {
-        downloadWorkThread(res, getApiFromName(apiName))
+        downloadWorkThread(res, getApiFromName(apiName), context ?: return)
         readEpub(res.author, res.name, apiName, res.synopsis)
     }
 
@@ -1258,7 +1286,12 @@ object BookDownloader2 {
     }
 
     private val deleteNovelMutex = Mutex()
-    private suspend fun deleteNovelAsync(author: String?, name: String, apiName: String) {
+    private suspend fun deleteNovelAsync(
+        context: Context,
+        author: String?,
+        name: String,
+        apiName: String
+    ) {
         if (deleteNovelMutex.isLocked) return
         deleteNovelMutex.withLock {
             val id = generateId(apiName, author, name)
@@ -1275,7 +1308,7 @@ object BookDownloader2 {
             }
 
             // delete the novel
-            BookDownloader2Helper.deleteNovel(activity, author, name, apiName)
+            BookDownloader2Helper.deleteNovel(context, author, name, apiName)
 
             // remove from info
             downloadInfoMutex.withLock {
@@ -1289,7 +1322,7 @@ object BookDownloader2 {
     }
 
     fun deleteNovel(author: String?, name: String, apiName: String) = ioSafe {
-        deleteNovelAsync(author, name, apiName)
+        deleteNovelAsync(context ?: return@ioSafe, author, name, apiName)
     }
 
 
@@ -1471,13 +1504,14 @@ object BookDownloader2 {
     }
 
     private suspend fun createNotification(
+        context: Context,
         id: Int,
         load: LoadResponse,
         stateProgressState: DownloadProgressState,
         progressInBytes: Boolean = false
     ) {
         NotificationHelper.createNotification(
-            activity,
+            context,
             load.url, id,
             load.name,
             load.posterUrl,
@@ -1577,6 +1611,7 @@ object BookDownloader2 {
     @WorkerThread
     suspend fun downloadWorkThread(
         card: DownloadFragment.DownloadDataLoaded,
+        context: Context,
     ) {
         if (card.isImported) {
             return
@@ -1612,7 +1647,7 @@ object BookDownloader2 {
                         //showToast("Id mismatch, migrating data from ${card.name} to ${res.name}")
                         migrateKeys(oldId, newId, card.name, res.name)
                         BookDownloader2Helper.copyAllData(
-                            activity,
+                            context,
                             card.author,
                             card.name,
                             card.apiName,
@@ -1620,20 +1655,20 @@ object BookDownloader2 {
                             res.name,
                             api.name
                         )
-                        deleteNovelAsync(card.author, card.name, card.apiName)
+                        deleteNovelAsync(context, card.author, card.name, card.apiName)
                     }
                 }
 
                 when (res) {
                     is EpubResponse -> {
                         downloadWorkThread(
-                            res, api
+                            res, api, context
                         )
                     }
 
                     is StreamResponse -> {
                         downloadWorkThread(
-                            res, api
+                            res, api, context
                         )
                     }
                 }
@@ -1655,6 +1690,7 @@ object BookDownloader2 {
     @WorkerThread
     suspend fun downloadWorkThread(
         card: ImmutableSearchResponse,
+        context: Context,
     ) {
         if (card.isImported) {
             return
@@ -1691,7 +1727,7 @@ object BookDownloader2 {
                         //showToast("Id mismatch, migrating data from ${card.name} to ${res.name}")
                         migrateKeys(oldId, newId, card.name, res.name)
                         BookDownloader2Helper.copyAllData(
-                            activity,
+                            context,
                             card.author,
                             card.name,
                             card.apiName,
@@ -1699,20 +1735,20 @@ object BookDownloader2 {
                             res.name,
                             api.name
                         )
-                        deleteNovelAsync(card.author, card.name, card.apiName)
+                        deleteNovelAsync(context, card.author, card.name, card.apiName)
                     }
                 }
 
                 when (res) {
                     is EpubResponse -> {
                         downloadWorkThread(
-                            res, api
+                            res, api, context
                         )
                     }
 
                     is StreamResponse -> {
                         downloadWorkThread(
-                            res, api
+                            res, api, context
                         )
                     }
                 }
@@ -1868,7 +1904,8 @@ object BookDownloader2 {
     private suspend fun handleDownloadActions(
         id: Int,
         load: EpubResponse,
-        current: DownloadState
+        current: DownloadState,
+        context: Context
     ): DownloadState {
         val action = consumeAction(id)
         val newState = when (action) {
@@ -1880,7 +1917,8 @@ object BookDownloader2 {
         if (newState != current || newState == DownloadState.IsPaused) updateDownloadNotificationState(
             id,
             load,
-            newState
+            newState,
+            context
         )
         return newState
     }
@@ -1889,6 +1927,7 @@ object BookDownloader2 {
         id: Int,
         load: EpubResponse,
         state: DownloadState,
+        context: Context,
         progress: Int? = null
     ) {
         changeDownload(id) {
@@ -1897,7 +1936,7 @@ object BookDownloader2 {
                 this.progress = it.toLong()
                 this.downloaded = it.toLong()
             }
-        }?.let { createNotification(id, load, it) }
+        }?.let { createNotification(context, id, load, it) }
     }
 
     fun pdfPageWithoutHAndF(page: PDPage, stripper: PDFTextStripperByArea): String {
@@ -2058,7 +2097,7 @@ object BookDownloader2 {
                 state = currentState
                 this.progress = chapterCount.toLong() - 1
                 this.downloaded = chapterCount.toLong() - 1
-            }?.let { createNotification(id, load, it) }
+            }?.let { createNotification(context, id, load, it) }
 
 
             //prototype of book
@@ -2078,7 +2117,7 @@ object BookDownloader2 {
             //init progress
             while (true) {
                 //check notification options
-                currentState = handleDownloadActions(id, load, currentState)
+                currentState = handleDownloadActions(id, load, currentState, context)
                 if (currentState == DownloadState.IsPaused) {
                     delay(200)
                     continue
@@ -2120,7 +2159,7 @@ object BookDownloader2 {
                             this.progress = chapterCount.toLong()
                             this.downloaded = chapterCount.toLong()
                         }?.let {
-                            createNotification(id, load, it)
+                            createNotification(context, id, load, it)
                         }
                     } else //finally
                     {
@@ -2171,17 +2210,17 @@ object BookDownloader2 {
                     state = DownloadState.IsDone
                     this.progress = this.total
                     this.downloaded = this.total
-                }?.let { createNotification(id, load, it) }
+                }?.let { createNotification(context, id, load, it) }
             } else {
                 changeDownload(id) {
                     state = DownloadState.IsStopped
-                }?.let { createNotification(id, load, it) }
+                }?.let { createNotification(context, id, load, it) }
             }
         } catch (t: Throwable) {
             logError(t)
             changeDownload(id) {
                 state = DownloadState.IsFailed
-            }?.let { createNotification(id, load, it) }
+            }?.let { createNotification(context, id, load, it) }
         } finally {
             document.close()
             currentDownloadsMutex.withLock { currentDownloads -= id }
@@ -2233,7 +2272,7 @@ object BookDownloader2 {
     }
 
     fun preloadPartialImportedPdf(bk: ImmutableSearchResponse) {
-        val context = activity ?: return
+        val context = BaseApplication.context ?: return
         try {
             val finalBook = File(
                 File(context.filesDir, getDirectory(bk.apiName, bk.author ?: "", bk.name)),
@@ -2280,7 +2319,7 @@ object BookDownloader2 {
     @WorkerThread
     @Throws
     suspend fun downloadWorkThread(data: Uri, context: Context) {
-        val filesDir = activity?.filesDir ?: return
+        val filesDir = context.filesDir
         val contentResolver = context.contentResolver
         val fd = contentResolver.openFileDescriptor(data, "r")
             ?: throw ErrorLoadingException("Unable to open file descriptor")
@@ -2375,6 +2414,7 @@ object BookDownloader2 {
                 this.downloaded = this.total
             }?.let { newProgressState ->
                 createNotification(
+                    context,
                     id,
                     load,
                     newProgressState
@@ -2389,8 +2429,8 @@ object BookDownloader2 {
 
     //this is for complete epubs like from anna's archive
     @WorkerThread
-    suspend fun downloadWorkThread(load: EpubResponse, api: APIRepository) {
-        val filesDir = activity?.filesDir ?: return
+    suspend fun downloadWorkThread(load: EpubResponse, api: APIRepository, context: Context) {
+        val filesDir = context.filesDir
         val sApiName = BookDownloader2Helper.sanitizeFilename(api.name)
         val sAuthor = BookDownloader2Helper.sanitizeFilename(load.author ?: "")
         val sName = BookDownloader2Helper.sanitizeFilename(load.name)
@@ -2418,6 +2458,7 @@ object BookDownloader2 {
                 state = DownloadState.IsDownloading
             }?.let { newProgressState ->
                 createNotification(
+                    context,
                     id,
                     load,
                     newProgressState
@@ -2445,7 +2486,7 @@ object BookDownloader2 {
                             changeDownload(id) {
                                 state = newState
                             }?.let { progressState ->
-                                createNotification(id, load, progressState)
+                                createNotification(context, id, load, progressState)
                             }
                             currentState = newState
                         }
@@ -2518,6 +2559,7 @@ object BookDownloader2 {
                                             this.state = newState
                                         }
                                         createNotification(
+                                            context,
                                             id,
                                             load,
                                             state.copy(state = newState),
@@ -2540,6 +2582,7 @@ object BookDownloader2 {
                             if (lastUpdatedMs + 1000 < System.currentTimeMillis()) {
                                 lastUpdatedMs = System.currentTimeMillis()
                                 createNotification(
+                                    context,
                                     id,
                                     load,
                                     state,
@@ -2560,6 +2603,7 @@ object BookDownloader2 {
                     this.downloaded = this.total
                 }?.let { newProgressState ->
                     createNotification(
+                        context,
                         id,
                         load,
                         newProgressState
@@ -2573,6 +2617,7 @@ object BookDownloader2 {
                 state = DownloadState.IsFailed
             }?.let { newProgressState ->
                 createNotification(
+                    context,
                     id,
                     load,
                     newProgressState,
@@ -2623,23 +2668,23 @@ object BookDownloader2 {
     }
 
     @WorkerThread
-    suspend fun downloadWorkThread(load: StreamResponse, api: APIRepository) {
+    suspend fun downloadWorkThread(load: StreamResponse, api: APIRepository, context: Context) {
         val id = generateId(load, api.name)
         val desiredStart = (
                 getKey<Int>(
                     DOWNLOAD_OFFSET, id.toString(),
                 ) ?: 0
                 ).coerceIn(0, load.data.size)
-        downloadWorkThread(load, api, desiredStart until load.data.size)
+        downloadWorkThread(load, api, desiredStart until load.data.size, context)
     }
 
     @WorkerThread
     suspend fun downloadWorkThread(
         load: StreamResponse,
         api: APIRepository,
-        range: ClosedRange<Int>
+        range: ClosedRange<Int>,
+        context: Context
     ) {
-        val context = activity ?: return
         val filesDir = context.filesDir
         val sApiName = BookDownloader2Helper.sanitizeFilename(api.name)
         val sAuthor =
@@ -2683,7 +2728,7 @@ object BookDownloader2 {
                         changeDownload(id) {
                             state = newState
                         }?.let { progressState ->
-                            createNotification(id, load, progressState)
+                            createNotification(context, id, load, progressState)
                         }
                         currentState = newState
                     }
@@ -2733,7 +2778,7 @@ object BookDownloader2 {
                     state = currentState
                     etaMs = (timePerLoadMs * (range.endInclusive - index)).toLong()
                 }?.let { progressState ->
-                    createNotification(id, load, progressState)
+                    createNotification(context, id, load, progressState)
                 }
 
                 when (currentState) {
@@ -2746,6 +2791,7 @@ object BookDownloader2 {
                             state = currentState
                         }?.let { newProgressState ->
                             createNotification(
+                                context,
                                 id,
                                 load,
                                 newProgressState,
@@ -2771,6 +2817,7 @@ object BookDownloader2 {
                 // only notify done if we have actually done some work
                 if (downloadedTotal > 0)
                     createNotification(
+                        context,
                         id,
                         load,
                         progressState

--- a/app/src/main/java/com/lagradost/quicknovel/DownloadFileWorkManager.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/DownloadFileWorkManager.kt
@@ -1,17 +1,23 @@
 package com.lagradost.quicknovel
 
 import android.content.Context
+import android.content.pm.ServiceInfo
+import android.os.Build
 import androidx.annotation.WorkerThread
 import androidx.core.net.toUri
 import androidx.work.CoroutineWorker
 import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
+import androidx.work.ForegroundInfo
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import com.lagradost.quicknovel.BaseApplication.Companion.getKey
 import com.lagradost.quicknovel.BookDownloader2Helper.IMPORT_SOURCE
 import com.lagradost.quicknovel.BookDownloader2Helper.IMPORT_SOURCE_PDF
+import com.lagradost.quicknovel.BookDownloader2Helper.generateId
 import com.lagradost.quicknovel.mvvm.logError
+import com.lagradost.quicknovel.ui.common.ImmutableSearchResponse
 import com.lagradost.quicknovel.ui.download.DownloadFragment
 import com.lagradost.quicknovel.ui.download.DownloadViewModel
 import com.lagradost.quicknovel.util.Apis
@@ -24,6 +30,9 @@ class DownloadFileWorkManager(val context: Context, private val workerParams: Wo
     companion object {
         const val DATA = "data"
         const val ID = "id"
+
+        // Survives process death, unlike the payload in workData
+        const val DOWNLOAD_ID = "download_id"
 
         const val ID_REFRESH_DOWNLOADS = "REFRESH_DOWNLOADS"
         const val ID_REFRESH_READINGPROGRESS = "REFRESH_READINGPROGRESS"
@@ -115,15 +124,18 @@ class DownloadFileWorkManager(val context: Context, private val workerParams: Wo
             )
         }
 
-        private fun startDownload(data: Any, context: Context) {
+        private fun startDownload(data: Any, downloadId: Int, context: Context) {
             getWorkerManager(context).enqueueUniqueWork(
-                ID_DOWNLOAD + System.currentTimeMillis(),
+                // The id keeps a batch enqueued in the same millisecond from chaining under APPEND,
+                // where a single failure would cancel every download behind it
+                ID_DOWNLOAD + downloadId + "_" + System.currentTimeMillis(),
                 ExistingWorkPolicy.APPEND,
                 OneTimeWorkRequest.Builder(DownloadFileWorkManager::class.java)
                     .setInputData(
                         Data.Builder()
                             .putString(ID, ID_DOWNLOAD)
                             .putInt(DATA, insertWork(data))
+                            .putInt(DOWNLOAD_ID, downloadId)
                             .build()
                     )
                     .build()
@@ -134,7 +146,17 @@ class DownloadFileWorkManager(val context: Context, private val workerParams: Wo
             card: DownloadFragment.DownloadDataLoaded,
             context: Context
         ) {
-            startDownload(card, context)
+            startDownload(card, card.id, context)
+        }
+
+        fun download(
+            card: ImmutableSearchResponse,
+            context: Context
+        ) {
+            if (card.isImported) {
+                return
+            }
+            startDownload(card, card.id ?: return, context)
         }
 
         fun download(
@@ -144,8 +166,52 @@ class DownloadFileWorkManager(val context: Context, private val workerParams: Wo
             if(load.apiName == IMPORT_SOURCE || load.apiName == IMPORT_SOURCE_PDF) {
                 return
             }
-            startDownload(load, context)
+            startDownload(load, generateId(load, load.apiName), context)
         }
+    }
+
+    override suspend fun getForegroundInfo(): ForegroundInfo {
+        val notification = NotificationHelper.buildForegroundNotification(context)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(
+                NotificationHelper.FOREGROUND_NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            )
+        } else {
+            ForegroundInfo(NotificationHelper.FOREGROUND_NOTIFICATION_ID, notification)
+        }
+    }
+
+    /** Without this the worker is stopped after ~10 min and the process is frozen while cached */
+    private suspend fun runInForeground() {
+        try {
+            setForeground(getForegroundInfo())
+        } catch (t: Throwable) {
+            // ForegroundServiceStartNotAllowedException and friends, the download still runs
+            logError(t)
+        }
+    }
+
+    /** The in memory payload is lost on process death, so rebuild it from the stored keys */
+    private suspend fun retryFromStoredData(): Result {
+        val downloadId = this.workerParams.inputData.getInt(DOWNLOAD_ID, -1)
+        if (downloadId == -1) return Result.failure()
+
+        val stored = getKey<DownloadFragment.DownloadData>(DOWNLOAD_FOLDER, downloadId.toString())
+            ?: return Result.failure()
+
+        val api = Apis.getApiFromNameOrNull(stored.apiName) ?: return Result.failure()
+        val data = api.load(stored.source, allowCache = false)
+        // Without the cap a dead source retries forever, showing a notification on every backoff
+        if (data !is com.lagradost.quicknovel.mvvm.Resource.Success)
+            return if (runAttemptCount < 3) Result.retry() else Result.failure()
+
+        when (val res = data.value) {
+            is EpubResponse -> BookDownloader2.downloadWorkThread(res, api, context)
+            is StreamResponse -> BookDownloader2.downloadWorkThread(res, api, context)
+        }
+        return Result.success()
     }
 
     @WorkerThread
@@ -153,27 +219,41 @@ class DownloadFileWorkManager(val context: Context, private val workerParams: Wo
         val id = this.workerParams.inputData.getString(ID)
         when (id) {
             ID_DOWNLOAD -> {
+                runInForeground()
                 when (val data = popWork(this.workerParams.inputData.getInt(DATA, -1))) {
                     is StreamResponse -> {
-                        BookDownloader2.downloadWorkThread(data, Apis.getApiFromName(data.apiName))
+                        BookDownloader2.downloadWorkThread(
+                            data,
+                            Apis.getApiFromName(data.apiName),
+                            context
+                        )
                     }
 
                     is EpubResponse -> {
-                        BookDownloader2.downloadWorkThread(data, Apis.getApiFromName(data.apiName))
+                        BookDownloader2.downloadWorkThread(
+                            data,
+                            Apis.getApiFromName(data.apiName),
+                            context
+                        )
+                    }
+
+                    is ImmutableSearchResponse -> {
+                        BookDownloader2.downloadWorkThread(data, context)
                     }
 
                     is DownloadFragment.DownloadDataLoaded -> {
                         if(data.apiName == IMPORT_SOURCE_PDF)
                             BookDownloader2.downloadPDFWorkThread(data.source.toUri(), context)
                         else
-                            BookDownloader2.downloadWorkThread(data)
+                            BookDownloader2.downloadWorkThread(data, context)
                     }
 
-                    else -> return Result.failure()
+                    else -> return retryFromStoredData()
                 }
             }
 
             ID_REFRESH_DOWNLOADS -> {
+                runInForeground()
                 viewModel?.refreshInternal()
             }
 

--- a/app/src/main/java/com/lagradost/quicknovel/ui/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/ui/download/DownloadViewModel.kt
@@ -212,9 +212,10 @@ class DownloadViewModel : ViewModel() {
             }
         }
 
+        val ctx = context ?: return
         for (card in values) {
             if (card.downloadedTotal <= 0 || (card.downloadedCount * 100 / card.downloadedTotal) > 90) {
-                BookDownloader2.downloadWorkThread(card)
+                BookDownloader2.downloadWorkThread(card, ctx)
             }
         }
     }

--- a/app/src/main/java/com/lagradost/quicknovel/ui/download/DownloadViewModel2.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/ui/download/DownloadViewModel2.kt
@@ -40,7 +40,6 @@ import com.lagradost.quicknovel.ui.common.updateRow
 import com.lagradost.quicknovel.ui.common.updateRows
 import com.lagradost.quicknovel.ui.download.DownloadDialog.*
 import com.lagradost.quicknovel.util.ResultCached
-import com.lagradost.quicknovel.util.cmap
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.mutate
 import kotlinx.collections.immutable.persistentListOf
@@ -356,9 +355,10 @@ class DownloadViewModel2 : ViewModel(), ActionHandler<DownloadPageAction>,
             }
 
             SearchResponseOperation.Download -> {
-                viewModelScope.launch {
-                    BookDownloader2.downloadWorkThread(action.response)
-                }
+                DownloadFileWorkManager.download(
+                    action.response,
+                    BaseApplication.context ?: return
+                )
             }
 
             SearchResponseOperation.Pause -> {
@@ -417,10 +417,9 @@ class DownloadViewModel2 : ViewModel(), ActionHandler<DownloadPageAction>,
             }
         }
 
-        withContext(Dispatchers.IO) {
-            values.values.cmap { card ->
-                BookDownloader2.downloadWorkThread(card)
-            }
+        val context = BaseApplication.context ?: return
+        for (card in values.values) {
+            DownloadFileWorkManager.download(card, context)
         }
     }
 

--- a/app/src/main/java/com/lagradost/quicknovel/ui/result/ResultViewModel2.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/ui/result/ResultViewModel2.kt
@@ -7,8 +7,10 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.lagradost.quicknovel.APIRepository
+import com.lagradost.quicknovel.BaseApplication
 import com.lagradost.quicknovel.BaseApplication.Companion.setKey
 import com.lagradost.quicknovel.BookDownloader2
+import com.lagradost.quicknovel.DownloadFileWorkManager
 import com.lagradost.quicknovel.BookDownloader2.openQuickStream
 import com.lagradost.quicknovel.BookDownloader2Helper.createQuickStream
 import com.lagradost.quicknovel.ChapterData
@@ -281,9 +283,10 @@ class ResultViewModel2(
             }
 
             SearchResponseOperation.Download -> {
-                viewModelScope.launch {
-                    BookDownloader2.downloadWorkThread(action.response)
-                }
+                DownloadFileWorkManager.download(
+                    action.response,
+                    BaseApplication.context ?: return
+                )
             }
 
             SearchResponseOperation.Pause -> {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -221,6 +221,7 @@
     <string name="new_update_found_format">New update found!\n %s -> %s</string>
     <string name="download_started">Download started</string>
     <string name="download_failed">Download failed</string>
+    <string name="download_in_progress">Downloading…</string>
     <string name="update">Update</string>
     <string name="dont_show_again">Don\'t show again</string>
     <string name="downloaded">Downloaded</string>


### PR DESCRIPTION
Downloads stop shortly after the app leaves the foreground, and the notification
freezes or disappears with no error. There are three independent causes.

### 1. The Compose download button never used WorkManager

`ResultViewModel2` and `DownloadViewModel2` called `BookDownloader2.downloadWorkThread(...)`
directly inside `viewModelScope.launch { }`. That scope is cancelled when the ViewModel is
cleared, so the download dies as soon as the screen goes away — navigating back is enough,
the app does not even need to be backgrounded.

`DownloadFileWorkManager.download()` already existed, but only the older
`ResultViewModel` / `refreshCard` paths reached it.

Both call sites now enqueue work instead, via a new `ImmutableSearchResponse` overload.

### 2. The worker was never a foreground worker

`DownloadFileWorkManager` had no `getForegroundInfo()` and never called `setForeground()`.
A plain `CoroutineWorker` gets roughly ten minutes before WorkManager stops it, and once the
process is cached the network is throttled. The class comment says it exists to solve exactly
this problem, but the mechanism was never implemented — `DownloadNotificationService` is
declared `foregroundServiceType="dataSync"` in the manifest yet only ever handled the
pause/resume/stop notification taps.

The worker now promotes itself for `ID_DOWNLOAD` and `ID_REFRESH_DOWNLOADS`:

- `getForegroundInfo()` returns the three argument `ForegroundInfo` with
  `FOREGROUND_SERVICE_TYPE_DATA_SYNC` on API 29+, the two argument one below that
  (`minSdkVersion` is 23).
- The notification channel is created eagerly, before the first `setForeground()`, otherwise
  the foreground notification is invalid.
- `setForeground()` is wrapped in `try`/`catch`. It throws
  `ForegroundServiceStartNotAllowedException` when the app is not allowed to start a
  foreground service, and an uncaught throw would kill the worker outright.

`AndroidManifest.xml` also merges `foregroundServiceType="dataSync"` onto
`androidx.work.impl.foreground.SystemForegroundService`. WorkManager does not declare a type
itself, and Android 14+ rejects `startForeground` with a type that is not in the manifest.
Without this the promotion throws and is silently swallowed by the catch above.

### 3. The download path depended on a `WeakReference<Activity>`

`downloadWorkThread(StreamResponse, …)` opened with `val context = activity ?: return`, and
the `EpubResponse` and `Uri` overloads did the same with `activity?.filesDir ?: return`.
Once past that line the local reference is strong, so a download already in flight kept
running — but a download that *started* while `CommonActivity.activity` was already null
aborted instantly and silently.

Worse, `createNotification` re-read the global on every single call, so progress notifications
died mid download while the file writes carried on. That asymmetry is why the symptom looks
like "the download stopped" when it had not.

`Context` is now threaded explicitly through the `downloadWorkThread` overloads,
`createNotification`, `copyAllData` and `deleteNovel`, following the pattern
`downloadPDFWorkThread` already used. `filesDir` is identical for an Activity and the
Application context, so this is behaviour preserving.

The remaining `activity` uses are `turnToEpub` / `openEpub` / `hasEpub` / `createQuickStream`,
which are user initiated and correctly Activity scoped.

### Also

- The in memory `workData` map does not survive process death, so `popWork` returned null and
  the worker gave up with `Result.failure()`. The download id is now stored in the worker
  `Data`, and on a miss the request is rebuilt from the persisted `DOWNLOAD_FOLDER` key.
  Capped at three attempts so a dead source cannot retry forever. This also covers the
  "worker stopped mid download and got rescheduled" case.
- The unique work name includes the download id. `refreshDownloads()` enqueues in a loop, and
  with a purely millisecond based name a batch collides and chains under `APPEND`, where one
  failure cancels every download behind it.

### Testing

Builds clean against `compileSdk 37` / AGP 9.2.1. The merged manifest was checked to confirm
`SystemForegroundService` carries `foregroundServiceType="dataSync"` and stays enabled.

Verified on a Samsung Galaxy S25 Ultra (Android 15 or later, One UI): downloads started from
the app now continue while it is in the background, with the ongoing notification present and
progressing. That covers the Android 14+ path where `startForeground` requires the service
type to be declared in the manifest, on a vendor build with aggressive background management.
