### PR TITLE
Epub improved

### DIFF
--- a/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
@@ -97,6 +97,9 @@ import me.ag2s.epublib.domain.Resource
 import me.ag2s.epublib.epub.EpubReader
 import me.ag2s.epublib.epub.EpubWriter
 import me.ag2s.epublib.util.zip.AndroidZipFile
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Entities
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
@@ -751,10 +754,19 @@ object BookDownloader2Helper {
             if (firstChar == -1) {
                 return null
             } // Invalid File
+
             val title = text.substring(0, firstChar)
             val data = text.substring(firstChar + 1)
-            val html = if (!stripHtml) data else stripHtml(
-                data,
+            val document = Jsoup.parse(data)
+
+            document.outputSettings().apply {
+                //translate <br> to <br />, <img> to <img... /> etc.
+                syntax(Document.OutputSettings.Syntax.xml)
+                //translate special characters to their Unicode equivalent in xhtml
+                escapeMode(Entities.EscapeMode.xhtml)
+            }
+            val html = if (!stripHtml) document.html() else stripHtml(
+                document,
                 title,
                 index,
                 stripAuthorNotes

--- a/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
@@ -860,6 +860,31 @@ object BookDownloader2Helper {
                     fileName.nameWithoutExtension.toIntOrNull() ?: return@mapNotNull null
                 }?.filter { x -> x >= start }?.sorted()
 
+                val cssContent = """
+                    body {
+                      display: block;
+                      font-size: 1em;
+                      padding-left: 0;
+                      padding-right: 0;
+                      margin: 0 5pt;
+                    }
+                    p {
+                      display: block;
+                      margin: 1em 0;
+                    }
+                    @page {
+                      margin-bottom: 5pt;
+                      margin-top: 5pt;
+                    }
+                """.trimIndent()
+                val styleResource = Resource(
+                    "style.css",
+                    cssContent.toByteArray(),
+                    "style.css",
+                    MediaTypes.CSS
+                )
+                book.resources.add(styleResource)
+
                 chapters?.pmap { threadIndex ->
 
                     val filepath =
@@ -1892,7 +1917,9 @@ object BookDownloader2 {
     private fun createHtmlWrapper(title: String, content: String): String {
         return """
         <html xmlns="http://www.w3.org/1999/xhtml">
-            <head><meta charset="utf-8"/><title>$title</title></head>
+            <head>
+                <meta charset="utf-8"/><title>$title</title>
+            </head>
             <body>
                 $content
             </body>
@@ -2114,6 +2141,32 @@ object BookDownloader2 {
                     EpubWriter().write(book, fos)
                 }
             }
+
+                //add style
+                val cssContent = """
+                    body {
+                      display: block;
+                      font-size: 1em;
+                      padding-left: 0;
+                      padding-right: 0;
+                      margin: 0 5pt;
+                    }
+                    p {
+                      display: block;
+                      margin: 1em 0;
+                    }
+                    @page {
+                      margin-bottom: 5pt;
+                      margin-top: 5pt;
+                    }
+                """.trimIndent()
+                val styleResource = Resource(
+                    "style.css",
+                    cssContent.toByteArray(),
+                    "style.css",
+                    MediaTypes.CSS
+                )
+                book.resources.add(styleResource)
 
             //init progress
             while (true) {

--- a/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
@@ -17,7 +17,6 @@ import android.graphics.BitmapFactory
 import android.graphics.RectF
 import android.net.Uri
 import android.os.Build
-import android.os.Environment
 import android.provider.MediaStore
 import android.widget.Toast
 import androidx.activity.ComponentActivity
@@ -50,10 +49,10 @@ import com.lagradost.quicknovel.BookDownloader2Helper.IMPORT_SOURCE_PDF
 import com.lagradost.quicknovel.BookDownloader2Helper.createQuickStream
 import com.lagradost.quicknovel.BookDownloader2Helper.generateId
 import com.lagradost.quicknovel.BookDownloader2Helper.getDirectory
+import com.lagradost.quicknovel.BookDownloader2Helper.getGeneralCSStyleForEPUBs
 import com.lagradost.quicknovel.BookDownloader2Helper.getSafeByteArray
 import com.lagradost.quicknovel.CommonActivity.activity
 import com.lagradost.quicknovel.CommonActivity.showToast
-import com.lagradost.quicknovel.DataStore.getSharedPrefs
 import com.lagradost.quicknovel.DataStore.mapper
 import com.lagradost.quicknovel.ImageDownloader.getImageBitmapFromUrl
 import com.lagradost.quicknovel.NotificationHelper.etaToString
@@ -73,7 +72,6 @@ import com.lagradost.quicknovel.util.Coroutines.main
 import com.lagradost.quicknovel.util.Event
 import com.lagradost.quicknovel.util.ResultCached
 import com.lagradost.quicknovel.util.UIHelper.colorFromAttribute
-import com.lagradost.quicknovel.util.amap
 import com.lagradost.quicknovel.util.pmap
 import com.lagradost.safefile.SafeFile
 import com.tom_roush.pdfbox.android.PDFBoxResourceLoader
@@ -191,6 +189,32 @@ object BookDownloader2Helper {
 
     fun getFilenameIMG(apiName: String, author: String, name: String): String {
         return "${getDirectory(apiName, author, name)}${fs}poster.jpg".replace("$fs$fs", "$fs")
+    }
+
+    fun getGeneralCSStyleForEPUBs(): Resource {
+        val cssContent = """
+            body {
+              display: block;
+              font-size: 1em;
+              padding-left: 0;
+              padding-right: 0;
+              margin: 0 5pt;
+            }
+            p {
+              display: block;
+              margin: 1em 0;
+            }
+            @page {
+              margin-bottom: 5pt;
+              margin-top: 5pt;
+            }
+        """.trimIndent()
+        return Resource(
+            "style.css",
+            cssContent.toByteArray(),
+            "style.css",
+            MediaTypes.CSS
+        )
     }
 
 
@@ -860,30 +884,7 @@ object BookDownloader2Helper {
                     fileName.nameWithoutExtension.toIntOrNull() ?: return@mapNotNull null
                 }?.filter { x -> x >= start }?.sorted()
 
-                val cssContent = """
-                    body {
-                      display: block;
-                      font-size: 1em;
-                      padding-left: 0;
-                      padding-right: 0;
-                      margin: 0 5pt;
-                    }
-                    p {
-                      display: block;
-                      margin: 1em 0;
-                    }
-                    @page {
-                      margin-bottom: 5pt;
-                      margin-top: 5pt;
-                    }
-                """.trimIndent()
-                val styleResource = Resource(
-                    "style.css",
-                    cssContent.toByteArray(),
-                    "style.css",
-                    MediaTypes.CSS
-                )
-                book.resources.add(styleResource)
+                book.resources.add(getGeneralCSStyleForEPUBs())
 
                 chapters?.pmap { threadIndex ->
 
@@ -899,8 +900,8 @@ object BookDownloader2Helper {
                     Triple(
                         Resource(
                             "id$threadIndex",
-                            chap.html.toByteArray(),
-                            "chapter$threadIndex.html",
+                            packageAsXHtml(chap.title, chap.html).toByteArray(),
+                            "chapter${threadIndex}.html",
                             MediaTypes.XHTML
                         ),
                         threadIndex,
@@ -1913,21 +1914,6 @@ object BookDownloader2 {
     //to avoid img headers or icons
     val MIN_IMAGE_SIZE = 30 * 1024
 
-
-    private fun createHtmlWrapper(title: String, content: String): String {
-        return """
-        <html xmlns="http://www.w3.org/1999/xhtml">
-            <head>
-                <meta charset="utf-8"/><title>$title</title>
-            </head>
-            <body>
-                $content
-            </body>
-        </html>
-    """.trimIndent()
-    }
-
-
     //Import pdf area -----------------------------------------------
     private suspend fun handleDownloadActions(
         id: Int,
@@ -2142,31 +2128,7 @@ object BookDownloader2 {
                 }
             }
 
-                //add style
-                val cssContent = """
-                    body {
-                      display: block;
-                      font-size: 1em;
-                      padding-left: 0;
-                      padding-right: 0;
-                      margin: 0 5pt;
-                    }
-                    p {
-                      display: block;
-                      margin: 1em 0;
-                    }
-                    @page {
-                      margin-bottom: 5pt;
-                      margin-top: 5pt;
-                    }
-                """.trimIndent()
-                val styleResource = Resource(
-                    "style.css",
-                    cssContent.toByteArray(),
-                    "style.css",
-                    MediaTypes.CSS
-                )
-                book.resources.add(styleResource)
+            book.resources.add(getGeneralCSStyleForEPUBs())
 
             //init progress
             while (true) {
@@ -2201,7 +2163,7 @@ object BookDownloader2 {
                 // collect N pages as sections to chapters
                 if (pageIdx % pagesPerChapter == 0 || pageIdx == totalPages) {
                     val sectionTitle = "${context.getString(R.string.chapter)} $chapterCount"
-                    val htmlContent = createHtmlWrapper(sectionTitle, currentChapterText.toString())
+                    val htmlContent = packageAsXHtml(sectionTitle, currentChapterText.toString())
 
                     //add chapter to the book
                     File(tempFolder, "chapter$chapterCount.xhtml").writeText(htmlContent)

--- a/app/src/main/java/com/lagradost/quicknovel/MainAPI.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/MainAPI.kt
@@ -15,9 +15,7 @@ import com.lagradost.quicknovel.ui.UiImage
 import com.lagradost.quicknovel.ui.img
 import com.lagradost.quicknovel.util.DefaultImagesHeaders
 import kotlinx.coroutines.sync.Mutex
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.jsoup.nodes.Entities
 
 const val USER_AGENT =
     "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36"
@@ -146,30 +144,15 @@ fun packageAsXHtml(title: String, bodyHtml: String): String {
 }
 
 fun stripHtml(
-    txt: String,
+    document: Document,
     chapterName: String? = null,
     chapterIndex: Int? = null,
     stripAuthorNotes: Boolean
 ): String {
-    val document = Jsoup.parse(txt)
-    document.outputSettings().apply {
-        syntax(Document.OutputSettings.Syntax.xml)
-        escapeMode(Entities.EscapeMode.xhtml)
-    }
-
     try {
         if (stripAuthorNotes) {
             document.select("div.qnauthornotecontainer").remove()
         }
-
-        // FUCK THIS, LEGIT IN EVERY CHAPTER
-        document.select("p").forEach { p ->
-            val html = p.text()
-            if (html.contains("Translator:") && html.contains("Editor:")) {
-                p.remove()
-            }
-        }
-
         if (chapterName != null && chapterIndex != null) {
             for (a in document.allElements) {
                 if (a != null && a.hasText() &&
@@ -184,7 +167,14 @@ fun stripHtml(
     } catch (e: Exception) {
         logError(e)
     }
-    return document.body().html()
+
+    return document.html()
+        .replace(
+            "<p>.*<strong>Translator:.*?Editor:.*>".toRegex(),
+            ""
+        ) // FUCK THIS, LEGIT IN EVERY CHAPTER
+        .replace("<.*?Translator:.*?Editor:.*?>".toRegex(), "") // FUCK THIS, LEGIT IN EVERY CHAPTER
+
 }
 
 data class HomePageList(

--- a/app/src/main/java/com/lagradost/quicknovel/MainAPI.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/MainAPI.kt
@@ -130,6 +130,21 @@ val String?.textClean: String?
         ?.replace("\\+([A-z])".toRegex(), "$1") //\+([^-\s])
             )
 
+fun packageAsXHtml(title: String, bodyHtml: String): String {
+    return """
+        <?xml version='1.0' encoding='utf-8'?>
+        <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+        <head>
+            <title>$title</title>
+            <link rel="stylesheet" type="text/css" href="style.css"/>
+        </head>
+        <body>
+            $bodyHtml
+        </body>
+        </html>
+    """.trimIndent()
+}
+
 fun stripHtml(
     txt: String,
     chapterName: String? = null,
@@ -137,14 +152,9 @@ fun stripHtml(
     stripAuthorNotes: Boolean
 ): String {
     val document = Jsoup.parse(txt)
-    document.outputSettings().syntax(Document.OutputSettings.Syntax.xml)
-    document.outputSettings().escapeMode(Entities.EscapeMode.xhtml)
-
-    // Add external stylesheet link
-    document.head().appendElement("link").apply {
-        attr("rel", "stylesheet")
-        attr("type", "text/css")
-        attr("href", "style.css")
+    document.outputSettings().apply {
+        syntax(Document.OutputSettings.Syntax.xml)
+        escapeMode(Entities.EscapeMode.xhtml)
     }
 
     try {
@@ -155,7 +165,7 @@ fun stripHtml(
         // FUCK THIS, LEGIT IN EVERY CHAPTER
         document.select("p").forEach { p ->
             val html = p.text()
-            if (html.startsWith("Translator:") || html.startsWith("Editor:")) {
+            if (html.contains("Translator:") && html.contains("Editor:")) {
                 p.remove()
             }
         }
@@ -174,12 +184,7 @@ fun stripHtml(
     } catch (e: Exception) {
         logError(e)
     }
-
-    return "<?xml version='1.0' encoding='utf-8'?>\n" +
-            "<html xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:epub=\"http://www.idpf.org/2007/ops\">\n" +
-            document.head().outerHtml() + "\n" +
-            document.body().outerHtml() + "\n" +
-            "</html>"
+    return document.body().html()
 }
 
 data class HomePageList(

--- a/app/src/main/java/com/lagradost/quicknovel/MainAPI.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/MainAPI.kt
@@ -16,6 +16,8 @@ import com.lagradost.quicknovel.ui.img
 import com.lagradost.quicknovel.util.DefaultImagesHeaders
 import kotlinx.coroutines.sync.Mutex
 import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Entities
 
 const val USER_AGENT =
     "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36"
@@ -135,10 +137,29 @@ fun stripHtml(
     stripAuthorNotes: Boolean
 ): String {
     val document = Jsoup.parse(txt)
+    document.outputSettings().syntax(Document.OutputSettings.Syntax.xml)
+    document.outputSettings().escapeMode(Entities.EscapeMode.xhtml)
+
+    // Add external stylesheet link
+    document.head().appendElement("link").apply {
+        attr("rel", "stylesheet")
+        attr("type", "text/css")
+        attr("href", "style.css")
+    }
+
     try {
         if (stripAuthorNotes) {
             document.select("div.qnauthornotecontainer").remove()
         }
+
+        // FUCK THIS, LEGIT IN EVERY CHAPTER
+        document.select("p").forEach { p ->
+            val html = p.text()
+            if (html.startsWith("Translator:") || html.startsWith("Editor:")) {
+                p.remove()
+            }
+        }
+
         if (chapterName != null && chapterIndex != null) {
             for (a in document.allElements) {
                 if (a != null && a.hasText() &&
@@ -154,13 +175,11 @@ fun stripHtml(
         logError(e)
     }
 
-    return document.html()
-        .replace(
-            "<p>.*<strong>Translator:.*?Editor:.*>".toRegex(),
-            ""
-        ) // FUCK THIS, LEGIT IN EVERY CHAPTER
-        .replace("<.*?Translator:.*?Editor:.*?>".toRegex(), "") // FUCK THIS, LEGIT IN EVERY CHAPTER
-
+    return "<?xml version='1.0' encoding='utf-8'?>\n" +
+            "<html xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:epub=\"http://www.idpf.org/2007/ops\">\n" +
+            document.head().outerHtml() + "\n" +
+            document.body().outerHtml() + "\n" +
+            "</html>"
 }
 
 data class HomePageList(

--- a/app/src/main/java/com/lagradost/quicknovel/util/AppUtils.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/util/AppUtils.kt
@@ -48,6 +48,8 @@ object AppUtils {
         } catch (t: Throwable) {
             false
         }
+
+    //Reminder: this is used to convert PDF text into HTML
     fun String.textToHtmlChapter(): String {
         return this
             .replace(Regex("((?<=\\p{Ll}(\\.{2,5})?),?) \\n(?=\\p{Ll})"), " ")

--- a/app/src/main/java/com/lagradost/quicknovel/util/AppUtils.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/util/AppUtils.kt
@@ -54,10 +54,9 @@ object AppUtils {
             .split(Regex("\\n"))
             .joinToString("") { paragraph ->
                 if (paragraph.trim().isNotBlank()) {
-                    paragraph.split(Regex("(?<=(?<!\\.)\\.)(?=\\s+)"))
-                        .joinToString("") { "<p>${it}</p>" } + "</br>"
+                    "<p>${paragraph.trim()}</p>"
                 } else {
-                    "</br>"
+                    "<br />"
                 }
             }
     }


### PR DESCRIPTION
When reading an EPUB created by QuickNovel in any old external reading app, paragraph spacing didn't work.
This PR fixes that by adding CSS styles to the EPUB files. These styles are recognized by external readers and correctly apply paragraph spacing.