### PR TITLE
Fix TTS stopping in background on Android 14+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build Android APK
+
+on:
+  push:
+    branches:
+      - fix-tts-android-14
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Build with Gradle
+      run: ./gradlew assembleDebug
+
+    - name: Upload APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: QuickNovel-Debug-APK
+        path: app/build/outputs/apk/debug/app-debug.apk

--- a/app/src/main/java/com/lagradost/quicknovel/TTSNotificationService.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/TTSNotificationService.kt
@@ -61,12 +61,19 @@ class TTSNotificationService : Service() {
 
         val viewModel : ReadActivityViewModel? = viewModel
         if (viewModel == null) {
-            startForeground(
-                TTSNotifications.TTS_NOTIFICATION_ID, TTSNotifications.createNotification(
-                    "Unknown", txt(""), null,
-                    TTSHelper.TTSStatus.IsRunning, this
-                )
-            )
+            TTSNotifications.createNotification(
+                "Unknown", txt(""), null,
+                TTSHelper.TTSStatus.IsRunning, this
+            )?.let { notification ->
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    startForeground(
+                        TTSNotifications.TTS_NOTIFICATION_ID, notification,
+                        android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+                    )
+                } else {
+                    startForeground(TTSNotifications.TTS_NOTIFICATION_ID, notification)
+                }
+            }
             stopSelf()
             return
         }
@@ -79,10 +86,20 @@ class TTSNotificationService : Service() {
             viewModel.book.poster(),
             TTSHelper.TTSStatus.IsRunning,
             this
-        )
+        ) ?: run {
+            stopSelf()
+            return
+        }
 
         try {
-            startForeground(TTSNotifications.TTS_NOTIFICATION_ID, notification)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                startForeground(
+                    TTSNotifications.TTS_NOTIFICATION_ID, notification,
+                    android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+                )
+            } else {
+                startForeground(TTSNotifications.TTS_NOTIFICATION_ID, notification)
+            }
         } catch (t: Throwable) {
             logError(t)
             showToast(t.toString())

--- a/app/src/main/java/com/lagradost/quicknovel/TTSNotifications.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/TTSNotifications.kt
@@ -116,7 +116,7 @@ object TTSNotifications {
                 .build()
             setMetadata(mediaMetadata)
             //setFlags(MediaSessionCompat.FLAG_HANDLES_MEDIA_BUTTONS or MediaSessionCompat.FLAG_HANDLES_TRANSPORT_CONTROLS)
-            //isActive = true
+            isActive = true
         }
     }
 


### PR DESCRIPTION
This pull request fixes an issue where the TTS stops playing when the screen is turned off or the app is switched to the background on Android 14 devices.

### Changes:
- Activated the `MediaSession` inside `TTSNotifications.kt` to comply with the Android 14 requirement that `mediaPlayback` foreground services must hold an active media session.
- Added the `FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK` explicitly when calling `startForeground` in `TTSNotificationService.kt` for devices running Android 10+.