### PR TITLE
Storage file

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ android {
 
     defaultConfig {
         applicationId "com.lagradost.quicknovel"
-        minSdkVersion 26
+        minSdkVersion 23
         targetSdkVersion 37
         versionCode 56
         versionName "3.7.4"
@@ -109,7 +109,7 @@ dependencies {
     implementation 'com.github.LagradOst:SafeFile:a926e7615a' // To Prevent the URI File Fu*kery
     implementation 'com.jaredrummler:colorpicker:1.1.0'
 
-    implementation "com.anggrayudi:storage:3.0.1"
+    implementation "com.github.lagradost:simplestorage:3ed3a412b701106b4ee11ac230d21bda365f4833"
 
     implementation 'com.github.Blatzar:NiceHttp:0.4.18'
     implementation "io.coil-kt.coil3:coil:3.5.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ android {
 
     defaultConfig {
         applicationId "com.lagradost.quicknovel"
-        minSdkVersion 23
+        minSdkVersion 26
         targetSdkVersion 37
         versionCode 56
         versionName "3.7.4"
@@ -108,6 +108,8 @@ dependencies {
     implementation 'androidx.media:media:1.7.1' // Media session aka notification
     implementation 'com.github.LagradOst:SafeFile:a926e7615a' // To Prevent the URI File Fu*kery
     implementation 'com.jaredrummler:colorpicker:1.1.0'
+
+    implementation "com.anggrayudi:storage:3.0.1"
 
     implementation 'com.github.Blatzar:NiceHttp:0.4.18'
     implementation "io.coil-kt.coil3:coil:3.5.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -106,9 +106,10 @@ dependencies {
     implementation("com.google.android.material:material:1.13.0")
 
     implementation 'androidx.media:media:1.7.1' // Media session aka notification
-    implementation 'com.github.LagradOst:SafeFile:a926e7615a' // To Prevent the URI File Fu*kery
+    //implementation 'com.github.LagradOst:SafeFile:a926e7615a' // To Prevent the URI File Fu*kery
     implementation 'com.jaredrummler:colorpicker:1.1.0'
 
+    // Custom fork for storage with android 23
     implementation "com.github.lagradost:simplestorage:3ed3a412b701106b4ee11ac230d21bda365f4833"
 
     implementation 'com.github.Blatzar:NiceHttp:0.4.18'

--- a/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
@@ -17,7 +17,6 @@ import android.graphics.BitmapFactory
 import android.graphics.RectF
 import android.net.Uri
 import android.os.Build
-import android.os.Environment
 import android.provider.MediaStore
 import android.widget.Toast
 import androidx.activity.ComponentActivity
@@ -39,7 +38,6 @@ import coil3.asDrawable
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
 import com.anggrayudi.storage.StorageFile
-import com.anggrayudi.storage.file.CreateMode
 import com.lagradost.quicknovel.BaseApplication.Companion.context
 import com.lagradost.quicknovel.BaseApplication.Companion.getKey
 import com.lagradost.quicknovel.BaseApplication.Companion.getKeys
@@ -55,7 +53,6 @@ import com.lagradost.quicknovel.BookDownloader2Helper.getDirectory
 import com.lagradost.quicknovel.BookDownloader2Helper.getSafeByteArray
 import com.lagradost.quicknovel.CommonActivity.activity
 import com.lagradost.quicknovel.CommonActivity.showToast
-import com.lagradost.quicknovel.DataStore.getSharedPrefs
 import com.lagradost.quicknovel.DataStore.mapper
 import com.lagradost.quicknovel.ImageDownloader.getImageBitmapFromUrl
 import com.lagradost.quicknovel.NotificationHelper.etaToString
@@ -65,7 +62,6 @@ import com.lagradost.quicknovel.mvvm.logError
 import com.lagradost.quicknovel.ui.ReadType
 import com.lagradost.quicknovel.ui.common.ImmutableSearchResponse
 import com.lagradost.quicknovel.ui.download.DownloadFragment
-import com.lagradost.quicknovel.ui.settings.SettingsFragment.Companion.downloadDirectory
 import com.lagradost.quicknovel.util.Apis.Companion.getApiFromName
 import com.lagradost.quicknovel.util.Apis.Companion.getApiFromNameOrNull
 import com.lagradost.quicknovel.util.AppUtils.textToHtmlChapter
@@ -75,7 +71,6 @@ import com.lagradost.quicknovel.util.Event
 import com.lagradost.quicknovel.util.ResultCached
 import com.lagradost.quicknovel.util.UIHelper.colorFromAttribute
 import com.lagradost.quicknovel.util.pmap
-import com.lagradost.safefile.SafeFile
 import com.tom_roush.pdfbox.android.PDFBoxResourceLoader
 import com.tom_roush.pdfbox.pdmodel.PDDocument
 import com.tom_roush.pdfbox.pdmodel.PDPage
@@ -103,10 +98,9 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
-import java.nio.file.Files
+import java.io.OutputStream
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.cancellation.CancellationException
-import kotlin.io.readBytes
 import kotlin.time.Duration.Companion.milliseconds
 
 enum class DownloadActionType {
@@ -361,26 +355,6 @@ object BookDownloader2Helper {
                 .use { it?.statSize ?: 0 }
         } catch (e: Exception) {
             null
-        }
-    }
-
-    fun hasEpub(activity: Activity?, name: String): Boolean {
-        if (activity == null) return false
-
-        if (!activity.checkWrite()) {
-            activity.requestRW()
-            return false
-        }
-
-        try {
-            val subDir =
-                activity.downloadDirectory()
-                    ?: throw IOException("No file")
-            val displayName = "${sanitizeFilename(name)}.epub"
-
-            return subDir.child(displayName)?.exists != null
-        } catch (_: Throwable) {
-            return false
         }
     }
 
@@ -652,48 +626,6 @@ object BookDownloader2Helper {
         }
     }
 
-    @Throws
-    fun openEpub(activity: Activity?, name: String, openInApp: Boolean? = null) {
-        if (activity == null) throw IOException("No activity")
-
-        if (!activity.checkWrite()) {
-            activity.requestRW()
-            return
-        }
-
-        val settingsManager = PreferenceManager.getDefaultSharedPreferences(activity)
-        val subDir = context?.downloadDirectory() ?: throw IOException("No file")
-        val displayName = "${sanitizeFilename(name)}.epub"
-        val foundFile = subDir.child(displayName) ?: throw IOException("No file")
-        val uri = foundFile.uri
-
-        val externalReader = settingsManager.getBoolean(
-            activity.getString(R.string.external_reader_key),
-            true
-        )
-        if (openInApp ?: !externalReader) {
-            val myIntent = Intent(activity, ReadActivity2::class.java)
-            myIntent.setDataAndType(uri, "application/epub+zip")
-            activity.startActivity(myIntent)
-            return
-        }
-
-        val intent = Intent().apply {
-            action = Intent.ACTION_VIEW
-            addFlags(
-                Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-                        or Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
-                        or Intent.FLAG_GRANT_PREFIX_URI_PERMISSION
-                        or Intent.FLAG_GRANT_READ_URI_PERMISSION
-            )
-        }
-
-        val type = "application/epub+zip"
-        intent.setDataAndType(uri, type)
-        activity.startActivity(intent)
-        //this.startActivityForResult(intent,1337) // SEE @moonreader
-    }
-
     private fun Context.getStripHtml(): Boolean {
         val settingsManager = PreferenceManager.getDefaultSharedPreferences(this)
         return (settingsManager.getBoolean(this.getString(R.string.remove_external_key), true))
@@ -787,32 +719,18 @@ object BookDownloader2Helper {
     @WorkerThread
     @Throws
     fun turnToEpub(
-        activity: Activity?,
-        author: String?,
-        name: String,
         apiName: String,
-        synopsis: String?
+        name: String,
+        author: String?,
+        synopsis: String?,
+        activity: Activity,
+        fileStream: OutputStream,
     ) {
-        if (activity == null) throw ErrorLoadingException("No activity")
-        if (!activity.checkWrite()) {
-            activity.requestRW()
-            return
-        }
-
         try {
             val sApiName = sanitizeFilename(apiName)
             val sAuthor = if (author == null) "" else sanitizeFilename(author)
             val sName = sanitizeFilename(name)
-            val id = "$sApiName$sAuthor$sName".hashCode()
-
-            val subDir = activity.downloadDirectory() ?: throw IOException("No download directory")
-
-            val displayName = "${sanitizeFilename(name)}.epub"
-
-            val file = subDir.createFile(displayName, mode = CreateMode.REPLACE) ?: throw IOException("Unable to create file")
-
-            val fileStream =
-                file.openOutputStream(append = false) ?: throw IOException("No outputfile")
+            val id = generateId(apiName, author, name)
 
             val epubFile = File(
                 activity.filesDir.toString() + getDirectory(sApiName, sAuthor, sName),
@@ -855,7 +773,6 @@ object BookDownloader2Helper {
                 }?.filter { x -> x >= start }?.sorted()
 
                 chapters?.pmap { threadIndex ->
-
                     val filepath =
                         head + getFilename(
                             sApiName,
@@ -894,10 +811,11 @@ object BookDownloader2Helper {
                 epubWriter.write(book, fileStream)
                 setKey(DOWNLOAD_EPUB_SIZE, id.toString(), largestChapter)
             }
-            fileStream.close()
         } catch (e: Exception) {
             logError(e)
             throw e
+        } finally {
+            fileStream.close()
         }
     }
 }
@@ -1179,7 +1097,13 @@ object BookDownloader2 {
     @WorkerThread
     suspend fun stream(res: EpubResponse, apiName: String) {
         downloadWorkThread(res, getApiFromName(apiName), context ?: return)
-        readEpub(res.author, res.name, apiName, res.synopsis)
+        readEpub(
+            author = res.author,
+            name = res.name,
+            apiName = apiName,
+            synopsis = res.synopsis,
+            alwaysGenerateNewFile = false
+        ) {}
     }
 
     @WorkerThread
@@ -1240,15 +1164,32 @@ object BookDownloader2 {
         }
     }
 
-    private fun generateAndReadEpub(
+    private fun readEpub(
         author: String?,
         name: String,
         apiName: String,
-        synopsis: String?
+        synopsis: String?,
+        alwaysGenerateNewFile: Boolean,
+        generating: () -> Unit = {},
     ) {
-        showToast(R.string.generating_epub)
         try {
-            turnToEpub(author, name, apiName, synopsis)
+            val activity = activity ?: return
+            val context = activity
+
+            if (alwaysGenerateNewFile) {
+                generating.invoke()
+                generateAndReadEpub(activity, author, name, apiName, synopsis)
+                return
+            }
+
+            val file = FileHelper.epub.openFile(context, name, false)
+            val uri = file?.uri
+            if (uri != null) {
+                openEpub(activity, uri)
+            } else {
+                generating.invoke()
+                generateAndReadEpub(activity, author, name, apiName, synopsis)
+            }
         } catch (e: ErrorLoadingException) {
             if (e.message != null) {
                 showToast(e.message)
@@ -1262,20 +1203,65 @@ object BookDownloader2 {
                 throw e
             }
         } catch (t: Throwable) {
+            logError(t)
             showToast(R.string.error_loading_novel)
         }
-        openEpub(name)
     }
 
-    private fun readEpub(
-        author: String?, name: String, apiName: String, synopsis: String?,
-        generating: () -> Unit = {}
+    private fun generateAndReadEpub(
+        activity: Activity,
+        author: String?,
+        name: String,
+        apiName: String,
+        synopsis: String?,
     ) {
-        if (hasEpub(name)) {
-            openEpub(name)
-        } else {
-            generateAndReadEpub(author, name, apiName, synopsis)
+        val file = FileHelper.epub.createFile(activity, name)
+            ?: throw ErrorLoadingException("Unable to create file")
+        val fileStream = file.openOutputStream(append = false)
+            ?: throw ErrorLoadingException("Unable to open inputstream")
+        BookDownloader2Helper.turnToEpub(
+            apiName,
+            name,
+            author,
+            synopsis,
+            activity,
+            fileStream
+        )
+        openEpub(activity, file.uri)
+    }
+
+    fun openEpub(
+        activity: Activity,
+        uri: Uri
+    ) {
+        val settingsManager = PreferenceManager.getDefaultSharedPreferences(activity)
+
+        val externalReader = settingsManager.getBoolean(
+            activity.getString(R.string.external_reader_key),
+            true
+        )
+
+        if (!externalReader) {
+            val myIntent = Intent(activity, ReadActivity2::class.java)
+            myIntent.setDataAndType(uri, "application/epub+zip")
+            activity.startActivity(myIntent)
+            return
         }
+
+        val exportedUri = FileHelper.exportUri(activity, uri)
+
+        val intent = Intent().apply {
+            action = Intent.ACTION_VIEW
+            addFlags(
+                Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                        or Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
+                        or Intent.FLAG_GRANT_PREFIX_URI_PERMISSION
+                        or Intent.FLAG_GRANT_READ_URI_PERMISSION
+            )
+        }
+
+        intent.setDataAndType(exportedUri, FileHelper.EPUB_MIME)
+        activity.startActivity(intent)
     }
 
     private val readEpubMutex = Mutex()
@@ -1294,12 +1280,14 @@ object BookDownloader2 {
         readEpubMutex.withLock {
             val downloaded = getKey(DOWNLOAD_EPUB_SIZE, id.toString(), 0)!!
             val shouldUpdate = downloadedCount - downloaded != 0
-            if (shouldUpdate) {
-                generating.invoke()
-                generateAndReadEpub(author, name, apiName, synopsis)
-            } else {
-                readEpub(author, name, apiName, synopsis, generating)
-            }
+            readEpub(
+                author = author,
+                name = name,
+                apiName = apiName,
+                synopsis = synopsis,
+                alwaysGenerateNewFile = shouldUpdate,
+                generating = generating
+            )
         }
     }
 
@@ -1412,40 +1400,6 @@ object BookDownloader2 {
         }
     }
 
-    @WorkerThread
-    @Throws
-    private fun turnToEpub(
-        author: String?,
-        name: String,
-        apiName: String,
-        synopsis: String?
-    ) {
-        return BookDownloader2Helper.turnToEpub(activity, author, name, apiName, synopsis)
-    }
-
-    private fun hasEpub(name: String): Boolean {
-        return BookDownloader2Helper.hasEpub(activity, name)
-    }
-
-    private fun openEpub(name: String, openInApp: Boolean? = null) {
-        try {
-            BookDownloader2Helper.openEpub(activity, name, openInApp)
-        } catch (e: ErrorLoadingException) {
-            if (e.message != null) {
-                showToast(e.message)
-            } else {
-                throw e
-            }
-        } catch (e: IOException) {
-            if (e.message != null) {
-                showToast(e.message)
-            } else {
-                throw e
-            }
-        } catch (t: Throwable) {
-            showToast(R.string.error_loading_novel)
-        }
-    }
 
     val downloadInfoMutex = Mutex()
     val downloadProgress: ConcurrentHashMap<Int, DownloadProgressState> = ConcurrentHashMap()

--- a/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/BookDownloader2.kt
@@ -38,6 +38,8 @@ import coil3.SingletonImageLoader
 import coil3.asDrawable
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
+import com.anggrayudi.storage.StorageFile
+import com.anggrayudi.storage.file.CreateMode
 import com.lagradost.quicknovel.BaseApplication.Companion.context
 import com.lagradost.quicknovel.BaseApplication.Companion.getKey
 import com.lagradost.quicknovel.BaseApplication.Companion.getKeys
@@ -63,8 +65,7 @@ import com.lagradost.quicknovel.mvvm.logError
 import com.lagradost.quicknovel.ui.ReadType
 import com.lagradost.quicknovel.ui.common.ImmutableSearchResponse
 import com.lagradost.quicknovel.ui.download.DownloadFragment
-import com.lagradost.quicknovel.ui.settings.SettingsFragment.Companion.getBasePath
-import com.lagradost.quicknovel.ui.settings.SettingsFragment.Companion.getDefaultDir
+import com.lagradost.quicknovel.ui.settings.SettingsFragment.Companion.downloadDirectory
 import com.lagradost.quicknovel.util.Apis.Companion.getApiFromName
 import com.lagradost.quicknovel.util.Apis.Companion.getApiFromNameOrNull
 import com.lagradost.quicknovel.util.AppUtils.textToHtmlChapter
@@ -73,7 +74,6 @@ import com.lagradost.quicknovel.util.Coroutines.main
 import com.lagradost.quicknovel.util.Event
 import com.lagradost.quicknovel.util.ResultCached
 import com.lagradost.quicknovel.util.UIHelper.colorFromAttribute
-import com.lagradost.quicknovel.util.amap
 import com.lagradost.quicknovel.util.pmap
 import com.lagradost.safefile.SafeFile
 import com.tom_roush.pdfbox.android.PDFBoxResourceLoader
@@ -103,6 +103,7 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
+import java.nio.file.Files
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.io.readBytes
@@ -373,12 +374,11 @@ object BookDownloader2Helper {
 
         try {
             val subDir =
-                activity.getBasePath().first ?: getDefaultDir(activity)
-                ?: throw IOException("No file")
+                activity.downloadDirectory()
+                    ?: throw IOException("No file")
             val displayName = "${sanitizeFilename(name)}.epub"
-            val foundFile = subDir.findFileOrThrow(displayName)
 
-            return foundFile.uri() != null
+            return subDir.child(displayName)?.exists != null
         } catch (_: Throwable) {
             return false
         }
@@ -662,10 +662,10 @@ object BookDownloader2Helper {
         }
 
         val settingsManager = PreferenceManager.getDefaultSharedPreferences(activity)
-        val subDir =
-            activity.getBasePath().first ?: getDefaultDir(activity) ?: throw IOException("No file")
+        val subDir = context?.downloadDirectory() ?: throw IOException("No file")
         val displayName = "${sanitizeFilename(name)}.epub"
-        val foundFile = subDir.findFileOrThrow(displayName)
+        val foundFile = subDir.child(displayName) ?: throw IOException("No file")
+        val uri = foundFile.uri
 
         val externalReader = settingsManager.getBoolean(
             activity.getString(R.string.external_reader_key),
@@ -673,7 +673,7 @@ object BookDownloader2Helper {
         )
         if (openInApp ?: !externalReader) {
             val myIntent = Intent(activity, ReadActivity2::class.java)
-            myIntent.setDataAndType(foundFile.uriOrThrow(), "application/epub+zip")
+            myIntent.setDataAndType(uri, "application/epub+zip")
             activity.startActivity(myIntent)
             return
         }
@@ -689,9 +689,7 @@ object BookDownloader2Helper {
         }
 
         val type = "application/epub+zip"
-        intent.setDataAndType(
-            foundFile.uriOrThrow(), type
-        )
+        intent.setDataAndType(uri, type)
         activity.startActivity(intent)
         //this.startActivityForResult(intent,1337) // SEE @moonreader
     }
@@ -807,15 +805,11 @@ object BookDownloader2Helper {
             val sName = sanitizeFilename(name)
             val id = "$sApiName$sAuthor$sName".hashCode()
 
-            val subDir = activity.getBasePath().first ?: getDefaultDir(activity)
-            ?: throw IOException("No file")
+            val subDir = activity.downloadDirectory() ?: throw IOException("No download directory")
 
-            //val subDir = baseFile.gotoDirectoryOrThrow("Epub", createMissingDirectories = true)
             val displayName = "${sanitizeFilename(name)}.epub"
 
-            //val relativePath = (Environment.DIRECTORY_DOWNLOADS + "${fs}Epub${fs}")
-            subDir.findFile(displayName)?.delete()
-            val file = subDir.createFileOrThrow(displayName)
+            val file = subDir.createFile(displayName, mode = CreateMode.REPLACE) ?: throw IOException("Unable to create file")
 
             val fileStream =
                 file.openOutputStream(append = false) ?: throw IOException("No outputfile")
@@ -2044,8 +2038,7 @@ object BookDownloader2 {
         val info = document.documentInformation
         val author =
             if (info.author.isNullOrBlank()) context.getString(R.string.unknown) else info.author
-        val fileName =
-            SafeFile.fromUri(context, data)?.name() ?: context.getString(R.string.unknown)
+        val fileName = StorageFile.from(context, data)?.name ?: context.getString(R.string.unknown)
         val name = fileName.removeSuffix(".pdf").removeSuffix(".PDF")
         val apiName = IMPORT_SOURCE_PDF
 

--- a/app/src/main/java/com/lagradost/quicknovel/FileHelper.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/FileHelper.kt
@@ -1,0 +1,174 @@
+package com.lagradost.quicknovel
+
+import android.Manifest.permission.READ_EXTERNAL_STORAGE
+import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
+import android.app.Activity
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.core.content.FileProvider
+import androidx.core.content.edit
+import androidx.core.net.toFile
+import androidx.core.net.toUri
+import androidx.preference.PreferenceManager
+import com.anggrayudi.storage.StorageFile
+import com.anggrayudi.storage.extension.isRawFile
+import com.anggrayudi.storage.file.CreateMode
+import com.anggrayudi.storage.file.MimeType
+import com.anggrayudi.storage.media.FileDescription
+import com.anggrayudi.storage.media.MediaStoreCompat
+import com.anggrayudi.storage.media.MediaType
+import com.anggrayudi.storage.toStorageFile
+import com.lagradost.quicknovel.mvvm.logError
+import com.lagradost.quicknovel.tachiyomi.AndroidPreferenceStore
+import com.lagradost.quicknovel.tachiyomi.PreferenceData
+
+data class FileStorage(
+    val mimeType: String,
+    val defaultSubFolder: String,
+    val key: Int,
+) {
+    val defaultLocation = "${Environment.DIRECTORY_DOWNLOADS}/$defaultSubFolder/"
+
+    fun setLocation(context: Context, uri: Uri?) {
+        val settingsManager = PreferenceManager.getDefaultSharedPreferences(context)
+        settingsManager.edit { putString(context.getString(key), uri?.toString()) }
+    }
+
+    fun getLocation(context: Context): Uri? {
+        val settingsManager = PreferenceManager.getDefaultSharedPreferences(context)
+        return settingsManager.getString(context.getString(key), null)?.toUri()
+    }
+
+    fun getVisualLocation(context: Context): String {
+        val uri = getLocation(context)
+        return if (uri != null) {
+            val absolutePath = uri.toStorageFile(context)?.absolutePath
+            absolutePath ?: uri.toString()
+        } else {
+            defaultLocation
+        }
+    }
+
+    fun openFile(context: Context, name: String, requiresWriteAccess: Boolean): StorageFile? {
+        FileHelper.requestStorage(context)
+        return FileHelper.openFile(
+            context,
+            getLocation(context),
+            defaultSubFolder,
+            name,
+            mimeType,
+            requiresWriteAccess
+        )
+    }
+
+    fun createFile(context: Context, name: String): StorageFile? {
+        FileHelper.requestStorage(context)
+        return FileHelper.createFile(context, getLocation(context), defaultSubFolder, name, mimeType)
+    }
+
+    fun toPreference(context: Context, store : AndroidPreferenceStore) : PreferenceData<String> {
+        return store.getString(
+            context.getString(key),
+            defaultLocation
+        )
+    }
+}
+
+
+object FileHelper {
+    const val EPUB_MIME = "application/epub+zip"
+    const val TEXT_MIME = "text/plain"
+    val epub = FileStorage(EPUB_MIME, "Epub", R.string.epub_path_key)
+    val backup = FileStorage(TEXT_MIME, "Backup", R.string.epub_path_key)
+    val logcat = FileStorage(TEXT_MIME, "Logcat", R.string.logcat_path_key)
+
+    fun requestStorage(context: Context) {
+        try {
+            ((context as? Activity) ?: CommonActivity.activity)?.let {
+                requestStorage(activity = it)
+            }
+        } catch (t : Throwable) {
+            logError(t)
+        }
+    }
+
+    fun requestStorage(activity: Activity) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            return
+        }
+        if (ContextCompat.checkSelfPermission(
+            activity,
+            WRITE_EXTERNAL_STORAGE
+        ) != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(
+                activity,
+                arrayOf(
+                    WRITE_EXTERNAL_STORAGE,
+                    READ_EXTERNAL_STORAGE
+                ),
+                1337
+            )
+        }
+    }
+
+    fun exportUri(context: Context, uri: Uri) : Uri {
+        return if(uri.isRawFile) {
+            FileProvider.getUriForFile(
+                context,
+                BuildConfig.APPLICATION_ID + ".provider",
+                uri.toFile()
+            )
+        } else {
+            uri
+        }
+    }
+
+    fun createFile(
+        context: Context,
+        storageLocation: Uri?,
+        defaultSubFolder: String,
+        name: String,
+        mimeType: String,
+    ): StorageFile? {
+        return if (storageLocation != null) {
+            StorageFile.from(context, storageLocation)
+                ?.createFile(name = name, mimeType = mimeType, CreateMode.REPLACE)
+        } else {
+            MediaStoreCompat.createDownload(
+                context = context,
+                file = FileDescription(
+                    name = name,
+                    defaultSubFolder,
+                    mimeType = mimeType
+                ),
+                mode = CreateMode.REPLACE
+            )?.toStorageFile(context)
+        }
+    }
+
+    fun openFile(
+        context: Context,
+        storageLocation: Uri?,
+        defaultSubFolder: String,
+        name: String,
+        mimeType: String,
+        requiresWriteAccess: Boolean
+    ): StorageFile? {
+        val mimeExt = MimeType.getExtensionFromMimeType(mimeType)
+        return if (storageLocation != null) {
+            StorageFile.from(context, storageLocation)
+                ?.child(path = "$name.$mimeExt", requiresWriteAccess = requiresWriteAccess)
+        } else {
+            MediaStoreCompat.fromBasePath(
+                context = context,
+                mediaType = MediaType.DOWNLOADS,
+                basePath = "${Environment.DIRECTORY_DOWNLOADS}/$defaultSubFolder/$name.$mimeExt"
+            )?.toStorageFile(context)
+        }
+    }
+}

--- a/app/src/main/java/com/lagradost/quicknovel/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/MainActivity.kt
@@ -23,6 +23,7 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.NavHostFragment
 import androidx.preference.PreferenceManager
+import com.anggrayudi.storage.StorageFile
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
@@ -74,7 +75,6 @@ import com.lagradost.quicknovel.util.UIHelper.getResourceColor
 import com.lagradost.quicknovel.util.UIHelper.html
 import com.lagradost.quicknovel.util.UIHelper.popupMenu
 import com.lagradost.quicknovel.util.UIHelper.setImage
-import com.lagradost.safefile.SafeFile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
@@ -378,16 +378,19 @@ class MainActivity : AppCompatActivity() {
                 val ctx = this
 
                 // RW perms for the path
-                ctx.contentResolver.takePersistableUriPermission(
-                    uri,
-                    Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-                )
+                try {
+                    ctx.contentResolver.takePersistableUriPermission(
+                        uri,
+                        Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                    )
+                } catch (t: Throwable) {
+                    logError(t)
+                }
 
-                val file = SafeFile.fromUri(ctx, uri)
-                val fileName = file?.name()
-
-                val mimeType = ctx.contentResolver.getType(uri)
-                println("Loaded epub file. Selected URI path: $uri - Name: $fileName")
+                val file = StorageFile.from(ctx, uri)
+                val fileName = file?.name
+                val mimeType = file?.mimeType //ctx.contentResolver.getType(uri)
+                println("Loaded epub file. Selected URI path: $uri - Name: $fileName with type $mimeType")
 
                 ioSafe {
                     try {

--- a/app/src/main/java/com/lagradost/quicknovel/ReadActivityViewModel.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/ReadActivityViewModel.kt
@@ -70,7 +70,6 @@ import com.lagradost.quicknovel.util.CoilImagesPlugin.CoilStore
 import com.lagradost.quicknovel.util.Coroutines.ioSafe
 import com.lagradost.quicknovel.util.Coroutines.runOnMainThread
 import com.lagradost.quicknovel.util.GoogleTranslateOnline
-import com.lagradost.safefile.closeQuietly
 import io.noties.markwon.AbstractMarkwonPlugin
 import io.noties.markwon.Markwon
 import io.noties.markwon.MarkwonConfiguration
@@ -1149,9 +1148,11 @@ class ReadActivityViewModel : ViewModel() {
 
     private suspend fun initMLFromSettings(settings: MLSettings, allowDownload: Boolean) {
         try {
-            mlTranslator?.closeQuietly()
-            mlTranslator = null
+            mlTranslator?.close()
+        } catch (_ : Throwable) {}
+        mlTranslator = null
 
+        try {
             if (settings.isInvalid() || settings.useOnlineTranslation) {
                 mlSettings = settings
                 return
@@ -1174,7 +1175,9 @@ class ReadActivityViewModel : ViewModel() {
             mlSettings = settings
         } catch (_: TimeoutException) {
             showToast(R.string.unable_to_download_language)
-            mlTranslator?.closeQuietly()
+            try {
+                mlTranslator?.close()
+            } catch (_ : Throwable) {}
             mlTranslator = null
         } catch (t: Throwable) {
             logError(t)

--- a/app/src/main/java/com/lagradost/quicknovel/providers/ScrollersPubProvider.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/providers/ScrollersPubProvider.kt
@@ -8,12 +8,12 @@ import com.lagradost.quicknovel.MainAPI
 import com.lagradost.quicknovel.R
 import com.lagradost.quicknovel.SearchResponse
 import com.lagradost.quicknovel.UserReview
+import com.lagradost.quicknovel.mvvm.logError
 import com.lagradost.quicknovel.newChapterData
 import com.lagradost.quicknovel.newReview
 import com.lagradost.quicknovel.newSearchResponse
 import com.lagradost.quicknovel.newStreamResponse
 import com.lagradost.quicknovel.setStatus
-import com.lagradost.safefile.logError
 import org.jsoup.Jsoup
 import java.net.URLEncoder
 

--- a/app/src/main/java/com/lagradost/quicknovel/ui/settings/SettingScreen.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/ui/settings/SettingScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.window.DialogProperties
 import com.anggrayudi.storage.StorageFile
 import com.anggrayudi.storage.file.CreateMode
 import com.anggrayudi.storage.file.MimeType
+import com.anggrayudi.storage.file.PublicDirectory
 import com.lagradost.quicknovel.CommonActivity.activity
 import com.lagradost.quicknovel.CommonActivity.showToast
 import com.lagradost.quicknovel.ErrorLoadingException
@@ -369,7 +370,25 @@ class SettingScreen : SearchableSettings {
                         subtitleProvider = { v, e ->
                             e[v] ?: v
                         },
-                        entries = (emptySet<String>() + "Custom").associateWith { it }
+                        entries = (
+                                listOfNotNull(
+                                    StorageFile.fromPublicDirectory(
+                                        context,
+                                        PublicDirectory.DOWNLOADS,
+                                        "/Epub/"
+                                    ),
+                                    StorageFile.fromPublicDirectory(
+                                        context,
+                                        PublicDirectory.DOCUMENTS,
+                                        "/Epub/"
+                                    ),
+                                    StorageFile.from(
+                                        context,
+                                        context.filesDir
+                                    ),
+                                ).mapNotNull { file ->
+                                    file.absolutePath
+                                }.associateWith { it } + ("Custom" to "Custom"))
                             .toPersistentMap(),
                         onValueChanged = { value ->
                             if (value != "Custom") {

--- a/app/src/main/java/com/lagradost/quicknovel/ui/settings/SettingScreen.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/ui/settings/SettingScreen.kt
@@ -43,6 +43,9 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.DialogProperties
+import com.anggrayudi.storage.StorageFile
+import com.anggrayudi.storage.file.CreateMode
+import com.anggrayudi.storage.file.MimeType
 import com.lagradost.quicknovel.CommonActivity.activity
 import com.lagradost.quicknovel.CommonActivity.showToast
 import com.lagradost.quicknovel.ErrorLoadingException
@@ -66,18 +69,14 @@ import com.lagradost.quicknovel.tachiyomi.Preference
 import com.lagradost.quicknovel.tachiyomi.SearchableSettings
 import com.lagradost.quicknovel.tachiyomi.TextPreferenceWidget
 import com.lagradost.quicknovel.tachiyomi.collectAsState
-import com.lagradost.quicknovel.ui.settings.SettingsFragment.Companion.getBasePath
-import com.lagradost.quicknovel.ui.settings.SettingsFragment.Companion.getDefaultDir
-import com.lagradost.quicknovel.ui.settings.SettingsFragment.Companion.getDownloadDirs
+import com.lagradost.quicknovel.ui.settings.SettingsFragment.Companion.downloadDirectory
 import com.lagradost.quicknovel.ui.txt
 import com.lagradost.quicknovel.util.Apis.Companion.apis
 import com.lagradost.quicknovel.util.AppUtils.openInBrowser
 import com.lagradost.quicknovel.util.BackupUtils
-import com.lagradost.quicknovel.util.BackupUtils.setupStream
 import com.lagradost.quicknovel.util.InAppUpdater.Companion.runAutoUpdate
 import com.lagradost.quicknovel.util.SubtitleHelper
 import com.lagradost.quicknovel.util.UIHelper.clipboardHelper
-import com.lagradost.safefile.SafeFile
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
@@ -103,7 +102,7 @@ class SettingScreen : SearchableSettings {
 
         val downloadVisualStore = store.getString(
             stringResource(R.string.download_path_visual),
-            safe { getDefaultDir(context)?.filePath() } ?: stringResource(R.string.unknown)
+            safe { context.downloadDirectory()?.absolutePath } ?: stringResource(R.string.unknown)
         )
 
         val downloadVisualStoreListener = downloadVisualStore.collectAsState()
@@ -113,14 +112,19 @@ class SettingScreen : SearchableSettings {
                 // It lies, it can be null if file manager quits.
                 if (uri == null) return@rememberLauncherForActivityResult
                 val context = context
-                // RW perms for the path
-                val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or
-                        Intent.FLAG_GRANT_WRITE_URI_PERMISSION
 
-                context.contentResolver.takePersistableUriPermission(uri, flags)
+                try {
+                    context.contentResolver.takePersistableUriPermission(
+                        uri, Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                                Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                    )
+                } catch (t: Throwable) {
+                    // remote shit can throw
+                    logError(t)
+                }
 
-                val file = SafeFile.fromUri(context, uri)
-                val filePath = file?.filePath()
+                val file = StorageFile.from(context, uri)
+                val filePath = file?.absolutePath
                 println("Selected URI path: $uri - Full path: $filePath")
 
                 // Stores the real URI using download_path_key
@@ -307,7 +311,7 @@ class SettingScreen : SearchableSettings {
                                     }
                                     .onSuccess { location ->
                                         showToast(
-                                            txt(R.string.backup_success, location) ,
+                                            txt(R.string.backup_success, location),
                                             Toast.LENGTH_LONG
                                         )
                                     }
@@ -365,7 +369,7 @@ class SettingScreen : SearchableSettings {
                         subtitleProvider = { v, e ->
                             e[v] ?: v
                         },
-                        entries = (getDownloadDirs(context) + "Custom").associateWith { it }
+                        entries = (emptySet<String>() + "Custom").associateWith { it }
                             .toPersistentMap(),
                         onValueChanged = { value ->
                             if (value != "Custom") {
@@ -460,6 +464,7 @@ fun LogcatDialog(dismiss: () -> Unit) {
     }
 
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     AlertDialog(
         containerColor = colors.background,
         onDismissRequest = dismiss,
@@ -476,30 +481,37 @@ fun LogcatDialog(dismiss: () -> Unit) {
         confirmButton = {
             Button(
                 onClick = {
-                    val date = SimpleDateFormat("yyyy_MM_dd_HH_mm", Locale.getDefault()).format(
-                        Date(System.currentTimeMillis())
-                    )
-                    var fileStream: OutputStream?
-                    try {
-                        fileStream = setupStream(
-                            context,
-                            "logcat_${date}",
-                            "txt",
-                            context.getBasePath().first ?: getDefaultDir(context)
-                            ?: throw IOException("No file")
-                        ) ?: throw ErrorLoadingException("No stream")
+                    scope.launch {
+                        withContext(Dispatchers.IO) {
+                            try {
+                                val date = SimpleDateFormat(
+                                    "yyyy_MM_dd_HH_mm",
+                                    Locale.getDefault()
+                                ).format(
+                                    Date(System.currentTimeMillis())
+                                )
 
-                        fileStream.writer().use { writer ->
-                            list.value.forEach {
-                                writer.write(it.toString())
-                                writer.write("\n\n")
+                                val fileName = "logcat_${date}.txt"
+                                val file =
+                                    context.downloadDirectory()
+                                        ?.createFile(fileName, MimeType.TEXT, CreateMode.REPLACE)
+                                        ?: throw IOException("Error creating file")
+                                val stream = file.openOutputStream()
+                                    ?: throw IOException("Error creating file")
+
+                                stream.bufferedWriter().use { writer ->
+                                    list.value.forEach {
+                                        writer.write(it.toString())
+                                        writer.write("\n\n")
+                                    }
+                                }
+                                dismiss()
+                                showToast(R.string.downloaded)
+                            } catch (t: Throwable) {
+                                logError(t)
+                                showToast(t.message)
                             }
                         }
-                        dismiss()
-                        showToast(R.string.downloaded)
-                    } catch (t: Throwable) {
-                        logError(t)
-                        showToast(t.message)
                     }
                 }, colors = whiteButtonColors
             ) { Text(text = stringResource(R.string.save)) }

--- a/app/src/main/java/com/lagradost/quicknovel/ui/settings/SettingScreen.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/ui/settings/SettingScreen.kt
@@ -43,15 +43,12 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.DialogProperties
-import com.anggrayudi.storage.StorageFile
-import com.anggrayudi.storage.file.CreateMode
-import com.anggrayudi.storage.file.MimeType
-import com.anggrayudi.storage.file.PublicDirectory
 import com.lagradost.quicknovel.CommonActivity.activity
 import com.lagradost.quicknovel.CommonActivity.showToast
 import com.lagradost.quicknovel.ErrorLoadingException
+import com.lagradost.quicknovel.FileHelper
+import com.lagradost.quicknovel.FileStorage
 import com.lagradost.quicknovel.R
-import com.lagradost.quicknovel.compose.BaseStyles
 import com.lagradost.quicknovel.compose.BaseStyles.blackButtonColors
 import com.lagradost.quicknovel.compose.BaseStyles.whiteButtonColors
 import com.lagradost.quicknovel.compose.CloudStreamPrimaryColor
@@ -64,13 +61,10 @@ import com.lagradost.quicknovel.compose.perfToMode
 import com.lagradost.quicknovel.compose.ripple
 import com.lagradost.quicknovel.compose.rounded
 import com.lagradost.quicknovel.mvvm.logError
-import com.lagradost.quicknovel.mvvm.safe
 import com.lagradost.quicknovel.tachiyomi.AndroidPreferenceStore
 import com.lagradost.quicknovel.tachiyomi.Preference
 import com.lagradost.quicknovel.tachiyomi.SearchableSettings
 import com.lagradost.quicknovel.tachiyomi.TextPreferenceWidget
-import com.lagradost.quicknovel.tachiyomi.collectAsState
-import com.lagradost.quicknovel.ui.settings.SettingsFragment.Companion.downloadDirectory
 import com.lagradost.quicknovel.ui.txt
 import com.lagradost.quicknovel.util.Apis.Companion.apis
 import com.lagradost.quicknovel.util.AppUtils.openInBrowser
@@ -79,13 +73,12 @@ import com.lagradost.quicknovel.util.InAppUpdater.Companion.runAutoUpdate
 import com.lagradost.quicknovel.util.SubtitleHelper
 import com.lagradost.quicknovel.util.UIHelper.clipboardHelper
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.io.IOException
-import java.io.OutputStream
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -95,25 +88,18 @@ class SettingScreen : SearchableSettings {
     override fun getTitleRes(): String = stringResource(R.string.title_settings)
 
     @Composable
-    override fun getPreferences(): List<Preference> {
+    fun getFilePreference(
+        storage : FileStorage,
+        store : AndroidPreferenceStore,
+        name : String,
+    ) : Preference.PreferenceItem<String> {
         val context = LocalContext.current
-        val store = AndroidPreferenceStore(context)
-        val scope = rememberCoroutineScope()
-        val downloadKeyStore = store.getString(stringResource(R.string.download_path_key))
-
-        val downloadVisualStore = store.getString(
-            stringResource(R.string.download_path_visual),
-            safe { context.downloadDirectory()?.absolutePath } ?: stringResource(R.string.unknown)
-        )
-
-        val downloadVisualStoreListener = downloadVisualStore.collectAsState()
+        val epubPathStore = storage.toPreference(context, store)
 
         val pathPicker =
             rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
                 // It lies, it can be null if file manager quits.
                 if (uri == null) return@rememberLauncherForActivityResult
-                val context = context
-
                 try {
                     context.contentResolver.takePersistableUriPermission(
                         uri, Intent.FLAG_GRANT_READ_URI_PERMISSION or
@@ -123,19 +109,51 @@ class SettingScreen : SearchableSettings {
                     // remote shit can throw
                     logError(t)
                 }
-
-                val file = StorageFile.from(context, uri)
-                val filePath = file?.absolutePath
-                println("Selected URI path: $uri - Full path: $filePath")
-
-                // Stores the real URI using download_path_key
-                // Important that the URI is stored instead of filepath due to permissions.
-                downloadKeyStore.set(uri.toString())
-
-                // From URI -> File path
-                // File path here is purely for cosmetic purposes in settings
-                downloadVisualStore.set(filePath ?: uri.toString())
+                storage.setLocation(context, uri)
             }
+        return Preference.PreferenceItem.ListPreference(
+            title = name,
+            icon = painterResource(R.drawable.netflix_download),
+            pref = epubPathStore,
+            subtitleProvider = { _, _ ->
+                storage.getVisualLocation(context)
+            },
+            entries =
+                persistentMapOf(
+                    storage.defaultLocation to storage.defaultLocation,
+                    "Custom" to stringResource(R.string.select_location)
+                ).toPersistentMap(),
+            onValueChanged = { value ->
+                when (value) {
+                    "Custom" -> {
+                        try {
+                            pathPicker.launch(Uri.EMPTY)
+                        } catch (t : Throwable) {
+                            logError(t)
+                            showToast(t.toString())
+                        }
+                    }
+                    else -> storage.setLocation(context, null)
+                }
+                return@ListPreference false
+            }
+        )
+    }
+
+    @Composable
+    override fun getPreferences(): List<Preference> {
+        val context = LocalContext.current
+        val store = AndroidPreferenceStore(context)
+        val scope = rememberCoroutineScope()
+
+        /*val backupPathStore = FileHelper.backup.toPreference(context, store)
+        val backupPath = backupPathStore.collectAsState()
+        val logcatPathStore = FileHelper.logcat.toPreference(context, store)
+        val logcatPath = backupPathStore.collectAsState()*/
+
+        val logcat = getFilePreference(FileHelper.logcat, store, stringResource(R.string.log_cat_location))
+        val backup = getFilePreference(FileHelper.backup, store, stringResource(R.string.backup_location))
+        val downloads = getFilePreference(FileHelper.epub, store, stringResource(R.string.download_path_pref))
 
         val restoreFileSelector =
             rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
@@ -289,7 +307,7 @@ class SettingScreen : SearchableSettings {
                     Preference.PreferenceItem.TextPreference(
                         icon = painterResource(R.drawable.baseline_save_as_24),
                         title = stringResource(R.string.backup_settings),
-                        subtitle = downloadVisualStoreListener.value,
+                        subtitle = null,
                         onClick = {
                             scope.launch {
                                 BackupUtils.createBackupFile(context, activity)
@@ -319,6 +337,7 @@ class SettingScreen : SearchableSettings {
                             }
                         }
                     ),
+                    backup,
                     Preference.PreferenceItem.TextPreference(
                         icon = painterResource(R.drawable.baseline_restore_page_24),
                         title = stringResource(R.string.restore_settings),
@@ -363,47 +382,7 @@ class SettingScreen : SearchableSettings {
                             true,
                         ),
                     ),
-                    Preference.PreferenceItem.ListPreference(
-                        title = stringResource(R.string.download_path_pref),
-                        icon = painterResource(R.drawable.netflix_download),
-                        pref = downloadVisualStore,
-                        subtitleProvider = { v, e ->
-                            e[v] ?: v
-                        },
-                        entries = (
-                                listOfNotNull(
-                                    StorageFile.fromPublicDirectory(
-                                        context,
-                                        PublicDirectory.DOWNLOADS,
-                                        "/Epub/"
-                                    ),
-                                    StorageFile.fromPublicDirectory(
-                                        context,
-                                        PublicDirectory.DOCUMENTS,
-                                        "/Epub/"
-                                    ),
-                                    StorageFile.from(
-                                        context,
-                                        context.filesDir
-                                    ),
-                                ).mapNotNull { file ->
-                                    file.absolutePath
-                                }.associateWith { it } + ("Custom" to "Custom"))
-                            .toPersistentMap(),
-                        onValueChanged = { value ->
-                            if (value != "Custom") {
-                                downloadKeyStore.set(value)
-                                true
-                            } else {
-                                try {
-                                    pathPicker.launch(Uri.EMPTY)
-                                } catch (t: Throwable) {
-                                    logError(t)
-                                }
-                                false
-                            }
-                        }
-                    ),
+                    downloads,
                 )
             ),
             Preference.PreferenceGroup(
@@ -426,9 +405,9 @@ class SettingScreen : SearchableSettings {
                                     showDialog = false
                                 }
                             }
-
                         }
                     ),
+                    logcat,
 
                     Preference.PreferenceItem.TextPreference(
                         icon = painterResource(R.drawable.ic_github_logo),
@@ -510,22 +489,26 @@ fun LogcatDialog(dismiss: () -> Unit) {
                                     Date(System.currentTimeMillis())
                                 )
 
-                                val fileName = "logcat_${date}.txt"
-                                val file =
-                                    context.downloadDirectory()
-                                        ?.createFile(fileName, MimeType.TEXT, CreateMode.REPLACE)
-                                        ?: throw IOException("Error creating file")
-                                val stream = file.openOutputStream()
-                                    ?: throw IOException("Error creating file")
+                                val file = FileHelper.logcat.createFile(context, "logcat_${date}")
+                                    ?: throw ErrorLoadingException("Unable to create file")
+                                val stream = file.openOutputStream(append = false)
+                                    ?: throw ErrorLoadingException("Unable to create stream")
 
-                                stream.bufferedWriter().use { writer ->
-                                    list.value.forEach {
-                                        writer.write(it.toString())
-                                        writer.write("\n\n")
+                                stream.bufferedWriter()
+                                    .use { writer ->
+                                        list.value.forEach {
+                                            writer.write(it.toString())
+                                            writer.write("\n\n")
+                                        }
                                     }
-                                }
                                 dismiss()
-                                showToast(R.string.downloaded)
+                                showToast(
+                                    txt(
+                                        R.string.logcat_success,
+                                        file.absolutePath ?: file.uri.toString()
+                                    ),
+                                    Toast.LENGTH_LONG
+                                )
                             } catch (t: Throwable) {
                                 logError(t)
                                 showToast(t.message)

--- a/app/src/main/java/com/lagradost/quicknovel/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/ui/settings/SettingsFragment.kt
@@ -105,8 +105,10 @@ class SettingsFragment : Fragment(), SearchableSettings by SettingScreen() {
             return when {
                 path.isNullOrBlank() -> StorageFile.fromPublicDirectory(
                     context,
-                    PublicDirectory.DOWNLOADS
-                )?.createFolder("Epub", CreateMode.SKIP_IF_EXISTS)
+                    PublicDirectory.DOWNLOADS,
+                    "/Epub/",
+                    requiresWriteAccess = true
+                )
 
                 path.startsWith("content://") || path.startsWith("file://") || path.startsWith("media/") -> StorageFile.from(
                     context,

--- a/app/src/main/java/com/lagradost/quicknovel/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/ui/settings/SettingsFragment.kt
@@ -36,10 +36,9 @@ import com.lagradost.quicknovel.util.Apis.Companion.apis
 import com.lagradost.quicknovel.util.Apis.Companion.getApiSettings
 import com.lagradost.quicknovel.util.SingleSelectionHelper.showMultiDialog
 import com.lagradost.quicknovel.util.SubtitleHelper
-import com.lagradost.safefile.MediaFileContentType
-import com.lagradost.safefile.SafeFile
-import kotlinx.coroutines.CoroutineScope
-import java.io.File
+import com.anggrayudi.storage.*
+import com.anggrayudi.storage.file.CreateMode
+import com.anggrayudi.storage.file.PublicDirectory
 
 // TODO logcat! and reorganize
 class SettingsFragment : Fragment(), SearchableSettings by SettingScreen() {
@@ -95,58 +94,81 @@ class SettingsFragment : Fragment(), SearchableSettings by SettingScreen() {
 
 
     companion object {
-        fun getDefaultDir(context: Context): SafeFile? {
-            // See https://www.py4u.net/discuss/614761
-            return SafeFile.fromMedia(
-                context, MediaFileContentType.Downloads
-            )?.gotoDirectory("Epub")
-        }
-
-        /**
-         * Turns a string to an UniFile. Used for stored string paths such as settings.
-         * Should only be used to get a download path.
-         * */
-        private fun basePathToFile(context: Context, path: String?): SafeFile? {
-            return when {
-                path.isNullOrBlank() -> getDefaultDir(context)
-                path.startsWith("content://") -> SafeFile.fromUri(context, path.toUri())
-                else -> SafeFile.fromFilePath(
-                    context,
-                    path.removePrefix(Environment.getExternalStorageDirectory().path).removePrefix(
-                        File.separator
-                    ).removeSuffix(File.separator) + File.separator
-                )
-            }
-        }
-
-        /**
-         * Base path where downloaded things should be stored, changes depending on settings.
-         * Returns the file and a string to be stored for future file retrieval.
-         * UniFile.filePath is not sufficient for storage.
-         * */
-        fun Context.getBasePath(): Pair<SafeFile?, String?> {
+        fun Context.downloadDirectory(): StorageFile? {
             val settingsManager = PreferenceManager.getDefaultSharedPreferences(this)
             val basePathSetting =
-                settingsManager.getString(getString(R.string.download_path_key), null)
-            return basePathToFile(this, basePathSetting) to basePathSetting
+                settingsManager.getString(this.getString(R.string.download_path_key), null)
+            return basePathToStorageFile(this, basePathSetting)
         }
 
-        fun getDownloadDirs(context: Context?): List<String> {
-            return safe {
-                context?.let { ctx ->
-                    val defaultDir = getDefaultDir(ctx)?.filePath()
+        private fun basePathToStorageFile(context: Context, path: String?): StorageFile? {
+            return when {
+                path.isNullOrBlank() -> StorageFile.fromPublicDirectory(
+                    context,
+                    PublicDirectory.DOWNLOADS
+                )?.createFolder("Epub", CreateMode.SKIP_IF_EXISTS)
 
-                    val first = listOf(defaultDir)
-                    (try {
-                        //val currentDir = ctx.getBasePath().let { it.first?.filePath() ?: it.second }
+                path.startsWith("content://") || path.startsWith("file://") || path.startsWith("media/") -> StorageFile.from(
+                    context,
+                    path.toUri()
+                )
 
-                        (first + ctx.getExternalFilesDirs("").mapNotNull { it.path })
-                    } catch (e: Exception) {
-                        first
-                    }).filterNotNull().distinct()
+                else -> StorageFile.fromPath(context, path, requiresWriteAccess = true)
+            }
+        }
+        /*
+                fun getDefaultDir(context: Context): SafeFile? {
+                    // See https://www.py4u.net/discuss/614761
+                    return SafeFile.fromMedia(
+                        context, MediaFileContentType.Downloads
+                    )?.gotoDirectory("Epub")
                 }
-            } ?: emptyList()
-        }
+
+                /**
+                 * Turns a string to an UniFile. Used for stored string paths such as settings.
+                 * Should only be used to get a download path.
+                 * */
+                private fun basePathToFile(context: Context, path: String?): SafeFile? {
+                    return when {
+                        path.isNullOrBlank() -> getDefaultDir(context)
+                        path.startsWith("content://") -> SafeFile.fromUri(context, path.toUri())
+                        else -> SafeFile.fromFilePath(
+                            context,
+                            path.removePrefix(Environment.getExternalStorageDirectory().path).removePrefix(
+                                File.separator
+                            ).removeSuffix(File.separator) + File.separator
+                        )
+                    }
+                }
+
+                /**
+                 * Base path where downloaded things should be stored, changes depending on settings.
+                 * Returns the file and a string to be stored for future file retrieval.
+                 * UniFile.filePath is not sufficient for storage.
+                 * */
+                fun Context.getBasePath(): Pair<SafeFile?, String?> {
+                    val settingsManager = PreferenceManager.getDefaultSharedPreferences(this)
+                    val basePathSetting =
+                        settingsManager.getString(getString(R.string.download_path_key), null)
+                    return basePathToFile(this, basePathSetting) to basePathSetting
+                }
+
+                fun getDownloadDirs(context: Context?): List<String> {
+                    return safe {
+                        context?.let { ctx ->
+                            val defaultDir = getDefaultDir(ctx)?.filePath()
+
+                            val first = listOf(defaultDir)
+                            (try {
+                                //val currentDir = ctx.getBasePath().let { it.first?.filePath() ?: it.second }
+
+                                (first + ctx.getExternalFilesDirs("").mapNotNull { it.path })
+                            } catch (e: Exception) {
+                                first
+                            }).filterNotNull().distinct()
+                        }
+                    } ?: emptyList()
+                }*/
 
         fun showSearchProviders(context: Context?) {
             if (context == null) return

--- a/app/src/main/java/com/lagradost/quicknovel/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/ui/settings/SettingsFragment.kt
@@ -94,30 +94,6 @@ class SettingsFragment : Fragment(), SearchableSettings by SettingScreen() {
 
 
     companion object {
-        fun Context.downloadDirectory(): StorageFile? {
-            val settingsManager = PreferenceManager.getDefaultSharedPreferences(this)
-            val basePathSetting =
-                settingsManager.getString(this.getString(R.string.download_path_key), null)
-            return basePathToStorageFile(this, basePathSetting)
-        }
-
-        private fun basePathToStorageFile(context: Context, path: String?): StorageFile? {
-            return when {
-                path.isNullOrBlank() -> StorageFile.fromPublicDirectory(
-                    context,
-                    PublicDirectory.DOWNLOADS,
-                    "/Epub/",
-                    requiresWriteAccess = true
-                )
-
-                path.startsWith("content://") || path.startsWith("file://") || path.startsWith("media/") -> StorageFile.from(
-                    context,
-                    path.toUri()
-                )
-
-                else -> StorageFile.fromPath(context, path, requiresWriteAccess = true)
-            }
-        }
         /*
                 fun getDefaultDir(context: Context): SafeFile? {
                     // See https://www.py4u.net/discuss/614761

--- a/app/src/main/java/com/lagradost/quicknovel/util/BackupUtils.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/util/BackupUtils.kt
@@ -11,6 +11,9 @@ import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.FragmentActivity
+import com.anggrayudi.storage.StorageFile
+import com.anggrayudi.storage.file.CreateMode
+import com.anggrayudi.storage.file.MimeType
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.lagradost.quicknovel.BookDownloader2Helper.checkWrite
@@ -25,9 +28,7 @@ import com.lagradost.quicknovel.ErrorLoadingException
 import com.lagradost.quicknovel.R
 import com.lagradost.quicknovel.mvvm.logError
 import com.lagradost.quicknovel.ui.settings.SettingsFragment
-import com.lagradost.quicknovel.ui.settings.SettingsFragment.Companion.getBasePath
-import com.lagradost.quicknovel.ui.settings.SettingsFragment.Companion.getDefaultDir
-import com.lagradost.safefile.SafeFile
+import com.lagradost.quicknovel.ui.settings.SettingsFragment.Companion.downloadDirectory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.IOException
@@ -53,45 +54,6 @@ object BackupUtils {
         @JsonProperty("datastore") val datastore: BackupVars,
         @JsonProperty("settings") val settings: BackupVars
     )
-
-    fun setupStream(
-        context: Context,
-        displayName: String,
-        ext: String,
-        subDir: SafeFile?
-    ): OutputStream? {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) { // && subDir?.isDownloadDir() == true
-            val cr = context.contentResolver
-            val contentUri =
-                MediaStore.Downloads.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY) // USE INSTEAD OF MediaStore.Downloads.EXTERNAL_CONTENT_URI
-            //val currentMimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
-
-            val newFile = ContentValues().apply {
-                put(MediaStore.MediaColumns.DISPLAY_NAME, displayName)
-                put(MediaStore.MediaColumns.TITLE, displayName)
-                put(MediaStore.MediaColumns.MIME_TYPE, "application/json")
-                //put(MediaStore.MediaColumns.RELATIVE_PATH, folder)
-            }
-
-            val newFileUri = cr.insert(
-                contentUri,
-                newFile
-            ) ?: throw IOException("Error creating file uri")
-            cr.openOutputStream(newFileUri, "w")
-                ?: throw IOException("Error opening stream")
-        } else {
-            val fileName = "$displayName.$ext"
-            val rFile = subDir?.findFile(fileName)
-            if (rFile?.exists() == true) {
-                rFile.delete()
-            }
-            val file =
-                subDir?.createFile(fileName)
-                    ?: throw IOException("Error creating file")
-            if (file.exists() != true) throw IOException("File does not exist")
-            file.openOutputStream()
-        }
-    }
 
     private fun <T> Context.restoreMap(
         map: Map<String, T>?,
@@ -127,7 +89,7 @@ object BackupUtils {
                     activity?.requestRW()
                     throw ErrorLoadingException()
                 }
-                val subDir = context.getBasePath().first ?: getDefaultDir(context)
+                val subDir = context.downloadDirectory()
                 ?: throw ErrorLoadingException("Invalid file directory")
                 val date = SimpleDateFormat("yyyy_MM_dd_HH_mm").format(Date(currentTimeMillis()))
                 val displayName = "QN_Backup_${date}"
@@ -166,7 +128,7 @@ object BackupUtils {
                 mapper.writeValue(stream, backupFile)
                 stream.close()
 
-                file.filePath() ?: "Unknown"
+                file.absolutePath ?: "Unknown"
             }
         }
 

--- a/app/src/main/java/com/lagradost/quicknovel/util/BackupUtils.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/util/BackupUtils.kt
@@ -1,43 +1,23 @@
 package com.lagradost.quicknovel.util
 
 import android.app.Activity
-import android.content.ContentValues
 import android.content.Context
 import android.net.Uri
-import android.os.Build
-import android.os.Environment
-import android.provider.MediaStore
-import android.widget.Toast
-import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.fragment.app.FragmentActivity
-import com.anggrayudi.storage.StorageFile
-import com.anggrayudi.storage.file.CreateMode
-import com.anggrayudi.storage.file.MimeType
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.lagradost.quicknovel.BookDownloader2Helper.checkWrite
 import com.lagradost.quicknovel.BookDownloader2Helper.requestRW
-import com.lagradost.quicknovel.CommonActivity.activity
-import com.lagradost.quicknovel.CommonActivity.showToast
 import com.lagradost.quicknovel.DataStore
 import com.lagradost.quicknovel.DataStore.getDefaultSharedPrefs
 import com.lagradost.quicknovel.DataStore.getSharedPrefs
 import com.lagradost.quicknovel.DataStore.mapper
 import com.lagradost.quicknovel.ErrorLoadingException
-import com.lagradost.quicknovel.R
-import com.lagradost.quicknovel.mvvm.logError
-import com.lagradost.quicknovel.ui.settings.SettingsFragment
-import com.lagradost.quicknovel.ui.settings.SettingsFragment.Companion.downloadDirectory
+import com.lagradost.quicknovel.FileHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.io.IOException
-import java.io.OutputStream
-import java.io.PrintWriter
 import java.lang.System.currentTimeMillis
 import java.text.SimpleDateFormat
-import java.util.*
-import kotlin.concurrent.thread
+import java.util.Date
 
 object BackupUtils {
     // Kinda hack, but I couldn't think of a better way
@@ -89,8 +69,6 @@ object BackupUtils {
                     activity?.requestRW()
                     throw ErrorLoadingException()
                 }
-                val subDir = context.downloadDirectory()
-                ?: throw ErrorLoadingException("Invalid file directory")
                 val date = SimpleDateFormat("yyyy_MM_dd_HH_mm").format(Date(currentTimeMillis()))
                 val displayName = "QN_Backup_${date}"
 
@@ -120,15 +98,15 @@ object BackupUtils {
                     allSettingsSorted
                 )
 
-                val file = subDir.createFile("$displayName.json")
-                    ?: throw ErrorLoadingException("Unable to create file, try changing download path to custom")
+                val file = FileHelper.backup.createFile(context, displayName)
+                    ?: throw ErrorLoadingException("Unable to create file")
                 val stream = file.openOutputStream(append = false)
-                    ?: throw ErrorLoadingException("Unable to create stream, try changing download path to custom")
+                    ?: throw ErrorLoadingException("Unable to create stream")
 
-                mapper.writeValue(stream, backupFile)
-                stream.close()
-
-                file.absolutePath ?: "Unknown"
+                stream.use { stream ->
+                    mapper.writeValue(stream, backupFile)
+                }
+                file.absolutePath ?: file.uri.toString()
             }
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,6 +48,7 @@
     <string name="delete">Delete</string>
     <string name="open_in_browser">Open In Browser</string>
     <string name="select_chapter">Select Chapter</string>
+    <string name="select_location">Select location</string>
     <string name="poster_descript">Poster</string>
     <string name="sort_downloads_descript">Sort Downloads</string>
     <string name="search_providers">Search Providers</string>
@@ -178,10 +179,12 @@
     <string name="twelve_hour_time">12 Hour time</string>
 
 
+    <string name="backup_location">Backup location</string>
     <string name="backup_settings">Backup data</string>
     <string name="restore_success">Loaded backup file</string>
     <string name="restore_failed_format" formatted="true">Failed to restore data from file %s</string>
     <string name="backup_success">Successfully stored data at %s</string>
+    <string name="logcat_success">Successfully stored logcat at %s</string>
     <string name="backup_failed">Storage permissions missing, please try again</string>
     <string name="backup_failed_error_format">Error backing up: %s</string>
     <string name="tts_locale">Language</string>
@@ -254,8 +257,12 @@
     <string name="ok">OK</string>
     <string name="more_info">More Info</string>
     <string name="download_path_key">download_path_key</string>
-    <string name="download_path_visual">Download path</string>
-    <string name="download_path_pref">Download path</string>
+
+    <string name="logcat_path_key">logcat_path_key</string>
+    <string name="epub_path_key">epub_path_key</string>
+    <string name="backup_path_key">backup_path_key</string>
+
+    <string name="download_path_pref">Download location</string>
     <string name="bionic_reading">Bionic Reading</string>
     <string name="selectable_text">Selectable text</string>
     <string name="sleep_timer">Sleep</string>
@@ -285,6 +292,7 @@
     <string name="clipboard_unknown_error">Error copying, Please copy logcat and contact app support.</string>
     <string name="show_log_cat">Show Logcat 🐈</string>
     <string name="log_cat">Logcat 🐈</string>
+    <string name="log_cat_location">Logcat location</string>
     <string name="unread">Unread</string>
     <string name="bookmarks">Bookmarks</string>
     <string name="bookmark">Bookmark</string>


### PR DESCRIPTION
This should solve all file issues new people have.

I tested this on an emulator on api 24 and 37, and a phone without issues. However any testing of the feature is highly appreciated ❤️ 

This was done by doing:
SafeFile -> SimpleStorage fork with api23
Random file apis -> Every file create/open using FileStorage to abstract away the file api
Download path -> Download location (Epub), Logcat location (Logcat) + Backup Location (Backup) 

Using MediaStore if no location is set, and using StorageFile for SAF when a custom location is set. This was the only way to avoid requesting storage perms for SAF, and still allow custom files. The downside of this is that all users have to manually change back the custom file path if they have already set one, as it is not kept to avoid issues with the old uris. 