### PR TITLE
Ranobes fix

### DIFF
--- a/app/src/main/java/com/lagradost/quicknovel/network/WebViewResolver.kt
+++ b/app/src/main/java/com/lagradost/quicknovel/network/WebViewResolver.kt
@@ -299,7 +299,7 @@ class WebViewResolver(
                                         if (!isCloudflarePage) return; 
                                         var cfToken = document.querySelector('[name="cf-turnstile-response"]')?.value 
                                                       || document.querySelector('#cf-chl-widget-multi-token')?.value;
-                                        var submitButton = document.querySelector('#challenge-form button[type="submit"]') 
+                                        var submitButton = document.querySelector('#challenge-form button[type="submit"], .antibot-btn-success') 
                                                            || document.querySelector('#challenge-form input[type="submit"]');
                                         if (cfToken && submitButton) {
                                             window.wasClicked = true;


### PR DESCRIPTION
The `WebViewResolver` JS was originally modified with the goal of clicking Ranobes' custom button. Apparently, they changed the class name. This should fix it.

I still have plans to improve `CloudflareKiller` further so that instead of passing a similar script multiple times, it simply passes selectors and conditions. But that's for later because I don't have time...